### PR TITLE
WIP FEATURE: Create Node of Document Nodes

### DIFF
--- a/Neos.EventSourcedNeosAdjustments/Classes/Ui/ContentRepository/Service/NodeService.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/Ui/ContentRepository/Service/NodeService.php
@@ -70,7 +70,7 @@ class NodeService
      * Converts a given context path to a node object
      *
      * @param string $contextPath
-     * @return NodeInterface|Error
+     * @return TraversableNode|Error
      */
     public function getNodeFromContextPath($contextPath)
     {

--- a/Neos.EventSourcedNeosAdjustments/Classes/Ui/ContentRepository/Service/NodeService.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/Ui/ContentRepository/Service/NodeService.php
@@ -11,7 +11,6 @@ namespace Neos\EventSourcedNeosAdjustments\Ui\ContentRepository\Service;
  * source code.
  */
 
-use Neos\ContentRepository\Domain\Projection\Content\NodeInterface;
 use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
 use Neos\Eel\FlowQuery\FlowQuery;
 use Neos\Error\Messages\Error;

--- a/Neos.EventSourcedNeosAdjustments/Classes/Ui/Domain/Model/AbstractChange.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/Ui/Domain/Model/AbstractChange.php
@@ -12,19 +12,19 @@ namespace Neos\EventSourcedNeosAdjustments\Ui\Domain\Model;
  * source code.
  */
 
-use Neos\ContentRepository\Domain\Projection\Content\NodeInterface;
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
 use Neos\Eel\FlowQuery\FlowQuery;
 use Neos\EventSourcedContentRepository\Domain\Projection\Workspace\WorkspaceFinder;
+use Neos\EventSourcedNeosAdjustments\Ui\Domain\Model\Feedback\Operations\NodeCreated;
 use Neos\EventSourcedNeosAdjustments\Ui\Domain\Model\Feedback\Operations\ReloadDocument;
 use Neos\EventSourcedNeosAdjustments\Ui\Domain\Model\Feedback\Operations\UpdateWorkspaceInfo;
 use Neos\Flow\Annotations as Flow;
-use Neos\Neos\Ui\Domain\Model\Feedback\Operations\NodeCreated;
 use Neos\Neos\Ui\Domain\Model\FeedbackCollection;
 
 abstract class AbstractChange implements ChangeInterface
 {
     /**
-     * @var NodeInterface
+     * @var TraversableNodeInterface
      */
     protected $subject;
 
@@ -44,10 +44,10 @@ abstract class AbstractChange implements ChangeInterface
     /**
      * Set the subject
      *
-     * @param NodeInterface $subject
+     * @param TraversableNodeInterface $subject
      * @return void
      */
-    public function setSubject(NodeInterface $subject)
+    public function setSubject(TraversableNodeInterface $subject)
     {
         $this->subject = $subject;
     }
@@ -55,7 +55,7 @@ abstract class AbstractChange implements ChangeInterface
     /**
      * Get the subject
      *
-     * @return NodeInterface
+     * @return TraversableNodeInterface
      */
     public function getSubject()
     {
@@ -83,7 +83,7 @@ abstract class AbstractChange implements ChangeInterface
      *
      * This method will be triggered if [nodeType].properties.[propertyName].ui.reloadIfChanged is TRUE.
      *
-     * @param NodeInterface $node
+     * @param TraversableNodeInterface $node
      * @return void
      */
     protected function reloadDocument($node = null)
@@ -99,7 +99,7 @@ abstract class AbstractChange implements ChangeInterface
     /**
      * Inform the client that a node has been created, the client decides if and which tree should react to this change.
      *
-     * @param NodeInterface $subject
+     * @param TraversableNodeInterface $subject
      * @return void
      */
     protected function addNodeCreatedFeedback($subject = null)

--- a/Neos.EventSourcedNeosAdjustments/Classes/Ui/Domain/Model/ChangeInterface.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/Ui/Domain/Model/ChangeInterface.php
@@ -11,7 +11,7 @@ namespace Neos\EventSourcedNeosAdjustments\Ui\Domain\Model;
  * source code.
  */
 
-use Neos\ContentRepository\Domain\Projection\Content\NodeInterface;
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
 
 /**
  * An interface to describe a change
@@ -22,15 +22,15 @@ interface ChangeInterface
     /**
      * Set the subject
      *
-     * @param NodeInterface $subject
+     * @param TraversableNodeInterface $subject
      * @return void
      */
-    public function setSubject(NodeInterface $subject);
+    public function setSubject(TraversableNodeInterface $subject);
 
     /**
      * Get the subject
      *
-     * @return NodeInterface
+     * @return TraversableNodeInterface
      */
     public function getSubject();
 

--- a/Neos.EventSourcedNeosAdjustments/Classes/Ui/Domain/Model/Changes/AbstractCreate.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/Ui/Domain/Model/Changes/AbstractCreate.php
@@ -1,0 +1,163 @@
+<?php
+namespace Neos\EventSourcedNeosAdjustments\Ui\Domain\Model\Changes;
+
+/*
+ * This file is part of the Neos.Neos.Ui package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\ContentRepository\Domain\Model\NodeType;
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
+use Neos\ContentRepository\Domain\Service\NodeServiceInterface;
+use Neos\ContentRepository\Domain\Service\NodeTypeManager;
+use Neos\EventSourcedNeosAdjustments\Ui\NodeCreationHandler\NodeCreationHandlerInterface;
+use Neos\Flow\Annotations as Flow;
+use Neos\Neos\Ui\Exception\InvalidNodeCreationHandlerException;
+
+abstract class AbstractCreate extends AbstractStructuralChange
+{
+    /**
+     * The type of the node that will be created
+     *
+     * @var NodeType
+     */
+    protected $nodeType;
+
+    /**
+     * @var NodeTypeManager
+     * @Flow\Inject
+     */
+    protected $nodeTypeManager;
+
+    /**
+     * Incoming data from creationDialog
+     *
+     * @var array
+     */
+    protected $data = [];
+
+    /**
+     * An (optional) name that will be used for the new node path
+     *
+     * @var string|null
+     */
+    protected $name = null;
+
+    /**
+     * @Flow\Inject
+     * @var NodeServiceInterface
+     */
+    protected $nodeService;
+
+    /**
+     * Set the node type
+     *
+     * @param string $nodeType
+     */
+    public function setNodeType($nodeType)
+    {
+        if (is_string($nodeType)) {
+            $nodeType = $this->nodeTypeManager->getNodeType($nodeType);
+        }
+
+        if (!$nodeType instanceof NodeType) {
+            throw new \InvalidArgumentException('nodeType needs to be of type string or NodeType', 1452100970);
+        }
+
+        $this->nodeType = $nodeType;
+    }
+
+    /**
+     * Get the node type
+     *
+     * @return NodeType
+     */
+    public function getNodeType()
+    {
+        return $this->nodeType;
+    }
+
+    /**
+     * Set the data
+     *
+     * @param array $data
+     */
+    public function setData(array $data)
+    {
+        $this->data = $data;
+    }
+
+    /**
+     * Get the data
+     *
+     * @return array
+     */
+    public function getData()
+    {
+        return $this->data;
+    }
+
+    /**
+     * Set the name
+     *
+     * @param string $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * Get the name
+     *
+     * @return string|null
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Apply nodeCreationHandlers
+     *
+     * @param TraversableNodeInterface $node
+     * @throws InvalidNodeCreationHandlerException
+     * @return void
+     */
+    protected function applyNodeCreationHandlers(TraversableNodeInterface $node)
+    {
+        $data = $this->getData() ?: [];
+        $nodeType = $node->getNodeType();
+        if (isset($nodeType->getOptions()['nodeCreationHandlers'])) {
+            $nodeCreationHandlers = $nodeType->getOptions()['nodeCreationHandlers'];
+            if (is_array($nodeCreationHandlers)) {
+                foreach ($nodeCreationHandlers as $nodeCreationHandlerConfiguration) {
+                    $nodeCreationHandler = new $nodeCreationHandlerConfiguration['nodeCreationHandler']();
+                    if (!$nodeCreationHandler instanceof NodeCreationHandlerInterface) {
+                        throw new InvalidNodeCreationHandlerException(sprintf('Expected NodeCreationHandlerInterface but got "%s"', get_class($nodeCreationHandler)), 1364759956);
+                    }
+                    $nodeCreationHandler->handle($node, $data);
+                }
+            }
+        }
+
+        $this->emitNodeCreationHandlersApplied($node);
+    }
+
+    /**
+     * Signals, that all changes by node creation handlers are applied
+     *
+     * @Flow\Signal
+     *
+     * @param TraversableNodeInterface $node The node, the node creation handlers are applied to
+     * @return void
+     */
+    public function emitNodeCreationHandlersApplied(TraversableNodeInterface $node)
+    {
+    }
+}

--- a/Neos.EventSourcedNeosAdjustments/Classes/Ui/Domain/Model/Changes/AbstractStructuralChange.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/Ui/Domain/Model/Changes/AbstractStructuralChange.php
@@ -1,0 +1,179 @@
+<?php
+namespace Neos\EventSourcedNeosAdjustments\Ui\Domain\Model\Changes;
+
+/*
+ * This file is part of the Neos.Neos.Ui package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
+use Neos\EventSourcedNeosAdjustments\Domain\Context\Content\NodeAddressFactory;
+use Neos\EventSourcedNeosAdjustments\Ui\ContentRepository\Service\NodeService;
+use Neos\EventSourcedNeosAdjustments\Ui\Domain\Model\AbstractChange;
+use Neos\EventSourcedNeosAdjustments\Ui\Domain\Model\Feedback\Operations\ReloadDocument;
+use Neos\EventSourcedNeosAdjustments\Ui\Domain\Model\Feedback\Operations\RenderContentOutOfBand;
+use Neos\EventSourcedNeosAdjustments\Ui\Domain\Model\Feedback\Operations\UpdateNodeInfo;
+use Neos\Flow\Annotations as Flow;
+use Neos\Neos\Ui\Domain\Model\RenderedNodeDomAddress;
+
+/**
+ * A change that performs structural actions like moving or creating nodes
+ */
+abstract class AbstractStructuralChange extends AbstractChange
+{
+    /**
+     * The node dom address for the parent node of the created node
+     *
+     * @var RenderedNodeDomAddress
+     */
+    protected $parentDomAddress;
+
+    /**
+     * The node dom address for the referenced sibling node of the created node
+     *
+     * @var RenderedNodeDomAddress
+     */
+    protected $siblingDomAddress;
+
+    /**
+     * @Flow\Inject
+     * @var NodeService
+     */
+    protected $nodeService;
+
+    /**
+     * @Flow\Inject
+     * @var NodeAddressFactory
+     */
+    protected $nodeAddressFactory;
+
+    /**
+     * @var TraversableNodeInterface
+     */
+    protected $cachedSiblingNode = null;
+
+    /**
+     * Get the insertion mode (before|after|into) that is represented by this change
+     *
+     * @return string
+     */
+    abstract public function getMode();
+
+    /**
+     * Set the parent node dom address
+     *
+     * @param RenderedNodeDomAddress $parentDomAddress
+     * @return void
+     */
+    public function setParentDomAddress(RenderedNodeDomAddress $parentDomAddress = null)
+    {
+        $this->parentDomAddress = $parentDomAddress;
+    }
+
+    /**
+     * Get the DOM address of the closest RENDERED node in the DOM tree.
+     *
+     * DOES NOT HAVE TO BE THE PARENT NODE!
+     *
+     * @return RenderedNodeDomAddress
+     */
+    public function getParentDomAddress()
+    {
+        return $this->parentDomAddress;
+    }
+
+    /**
+     * Set the sibling node dom address
+     *
+     * @param RenderedNodeDomAddress $siblingDomAddress
+     * @return void
+     */
+    public function setSiblingDomAddress(RenderedNodeDomAddress $siblingDomAddress = null)
+    {
+        $this->siblingDomAddress = $siblingDomAddress;
+    }
+
+    /**
+     * Get the sibling node dom address
+     *
+     * @return RenderedNodeDomAddress
+     */
+    public function getSiblingDomAddress()
+    {
+        return $this->siblingDomAddress;
+    }
+
+    /**
+     * Get the sibling node
+     *
+     * @return TraversableNodeInterface
+     */
+    public function getSiblingNode()
+    {
+        if ($this->siblingDomAddress === null) {
+            return null;
+        }
+
+        if ($this->cachedSiblingNode === null) {
+            $this->cachedSiblingNode = $this->nodeService->getNodeFromContextPath(
+                $this->siblingDomAddress->getContextPath()
+            );
+        }
+
+        return $this->cachedSiblingNode;
+    }
+
+    /**
+     * Perform finish tasks - needs to be called from inheriting class on `apply`
+     *
+     * @param TraversableNodeInterface $node
+     * @return void
+     */
+    protected function finish(TraversableNodeInterface $node)
+    {
+        $updateNodeInfo = new UpdateNodeInfo();
+        $updateNodeInfo->setNode($node);
+        $updateNodeInfo->recursive();
+
+        $updateParentNodeInfo = new UpdateNodeInfo();
+        $parentNode = $node->findParentNode();
+        $updateParentNodeInfo->setNode($parentNode);
+
+        $this->feedbackCollection->add($updateNodeInfo);
+        $this->feedbackCollection->add($updateParentNodeInfo);
+
+        $this->updateWorkspaceInfo();
+
+        if ($node->getNodeType()->isOfType('Neos.Neos:Content') && ($this->getParentDomAddress() || $this->getSiblingDomAddress())) {
+
+            // we can ONLY render out of band if:
+            // 1) the parent of our new (or copied or moved) node is a ContentCollection; so we can directly update an element of this content collection
+            if ($parentNode->getNodeType()->isOfType('Neos.Neos:ContentCollection') &&
+
+                // 2) the parent DOM address (i.e. the closest RENDERED node in DOM is actually the ContentCollection; and
+                //    no other node in between
+                $this->getParentDomAddress() &&
+                $this->getParentDomAddress()->getFusionPath() &&
+                $this->getParentDomAddress()->getContextPath() === $this->nodeAddressFactory->createFromNode($node->findParentNode())->serializeForUri()
+            ) {
+                $renderContentOutOfBand = new RenderContentOutOfBand();
+                $renderContentOutOfBand->setNode($node);
+                $renderContentOutOfBand->setParentDomAddress($this->getParentDomAddress());
+                $renderContentOutOfBand->setSiblingDomAddress($this->getSiblingDomAddress());
+                $renderContentOutOfBand->setMode($this->getMode());
+
+                $this->feedbackCollection->add($renderContentOutOfBand);
+            } else {
+                $reloadDocument = new ReloadDocument();
+                $reloadDocument->setNode($node);
+
+                $this->feedbackCollection->add($reloadDocument);
+            }
+        }
+    }
+}

--- a/Neos.EventSourcedNeosAdjustments/Classes/Ui/Domain/Model/Changes/Create.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/Ui/Domain/Model/Changes/Create.php
@@ -1,0 +1,102 @@
+<?php
+namespace Neos\EventSourcedNeosAdjustments\Ui\Domain\Model\Changes;
+
+/*
+ * This file is part of the Neos.Neos.Ui package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\ContentRepository\Domain\ValueObject\NodeAggregateIdentifier;
+use Neos\ContentRepository\Domain\ValueObject\NodeIdentifier;
+use Neos\ContentRepository\Domain\ValueObject\NodeName;
+use Neos\ContentRepository\Domain\ValueObject\NodeTypeName;
+use Neos\EventSourcedContentRepository\Domain\Context\Node\Command\CreateNodeAggregateWithNode;
+use Neos\EventSourcedContentRepository\Domain\Context\Node\NodeCommandHandler;
+use Neos\EventSourcedNeosAdjustments\Ui\Fusion\Helper\NodeInfoHelper;
+
+class Create extends AbstractCreate
+{
+
+    /**
+     * @Flow\Inject
+     * @var NodeCommandHandler
+     */
+    protected $nodeCommandHandler;
+
+    /**
+     * @param string $parentContextPath
+     */
+    public function setParentContextPath($parentContextPath)
+    {
+        // this method needs to exist; otherwise the TypeConverter breaks.
+    }
+
+    /**
+     * Get the insertion mode (before|after|into) that is represented by this change
+     *
+     * @return string
+     */
+    public function getMode()
+    {
+        return 'into';
+    }
+
+    /**
+     * Check if the new node's node type is allowed in the requested position
+     *
+     * @return boolean
+     */
+    public function canApply()
+    {
+        $subject = $this->getSubject();
+        $nodeType = $this->getNodeType();
+
+        return NodeInfoHelper::isNodeTypeAllowedAsChildNode($subject, $nodeType);
+    }
+
+    /**
+     * Create a new node beneath the subject
+     *
+     * @return void
+     */
+    public function apply()
+    {
+        if ($this->canApply()) {
+            $parentNode = $this->getSubject();
+
+            // TODO: the $name=... line should be as expressed below
+            // $name = $this->getName() ?: $this->nodeService->generateUniqueNodeName($parent->findParentNode());
+            $nodeName = new NodeName($this->getName() ?: uniqid('node-'));
+
+            $nodeAggregateIdentifier = new NodeAggregateIdentifier(); // generate a new NodeAggregateIdentifier
+
+            $command = new CreateNodeAggregateWithNode(
+                $parentNode->getContentStreamIdentifier(),
+                $nodeAggregateIdentifier,
+                new NodeTypeName($this->getNodeType()->getName()),
+                $parentNode->getDimensionSpacePoint(),
+                new NodeIdentifier(), // generate a new NodeIdentifier
+                $parentNode->getNodeIdentifier(),
+                $nodeName
+            );
+
+            $this->nodeCommandHandler->handleCreateNodeAggregateWithNode($command);
+
+            $newlyCreatedNode = $parentNode->findNamedChildNode($nodeName);
+            $this->applyNodeCreationHandlers($newlyCreatedNode);
+
+            $this->finish($newlyCreatedNode);
+            // NOTE: we need to run "finish" before "addNodeCreatedFeedback" to ensure the new node already exists when the last feedback is processed
+            $this->addNodeCreatedFeedback($newlyCreatedNode);
+
+
+            $this->updateWorkspaceInfo();
+        }
+    }
+}

--- a/Neos.EventSourcedNeosAdjustments/Classes/Ui/Domain/Model/Changes/CreateAfter.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/Ui/Domain/Model/Changes/CreateAfter.php
@@ -1,0 +1,57 @@
+<?php
+namespace Neos\EventSourcedNeosAdjustments\Ui\Domain\Model\Changes;
+
+/*
+ * This file is part of the Neos.Neos.Ui package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\EventSourcedNeosAdjustments\Ui\Fusion\Helper\NodeInfoHelper;
+
+class CreateAfter extends AbstractCreate
+{
+    /**
+     * Get the insertion mode (before|after|into) that is represented by this change
+     *
+     * @return string
+     */
+    public function getMode()
+    {
+        return 'after';
+    }
+
+    /**
+     * Check if the new node's node type is allowed in the requested position
+     *
+     * @return boolean
+     */
+    public function canApply()
+    {
+        $parent = $this->getSubject()->findParentNode();
+        $nodeType = $this->getNodeType();
+
+        return NodeInfoHelper::isNodeTypeAllowedAsChildNode($parent, $nodeType);
+    }
+
+    /**
+     * Create a new node after the subject
+     *
+     * @return void
+     */
+    public function apply()
+    {
+        if ($this->canApply()) {
+            $subject = $this->getSubject();
+            $parent = $subject->getParent();
+            $node = $this->createNode($parent);
+
+            $node->moveAfter($subject);
+            $this->updateWorkspaceInfo();
+        }
+    }
+}

--- a/Neos.EventSourcedNeosAdjustments/Classes/Ui/Domain/Model/Changes/CreateBefore.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/Ui/Domain/Model/Changes/CreateBefore.php
@@ -1,0 +1,57 @@
+<?php
+namespace Neos\EventSourcedNeosAdjustments\Ui\Domain\Model\Changes;
+
+/*
+ * This file is part of the Neos.Neos.Ui package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\EventSourcedNeosAdjustments\Ui\Fusion\Helper\NodeInfoHelper;
+
+class CreateBefore extends AbstractCreate
+{
+    /**
+     * Get the insertion mode (before|after|into) that is represented by this change
+     *
+     * @return string
+     */
+    public function getMode()
+    {
+        return 'before';
+    }
+
+    /**
+     * Check if the new node's node type is allowed in the requested position
+     *
+     * @return boolean
+     */
+    public function canApply()
+    {
+        $parent = $this->getSubject()->findParentNode();
+        $nodeType = $this->getNodeType();
+
+        return NodeInfoHelper::isNodeTypeAllowedAsChildNode($parent, $nodeType);
+    }
+
+    /**
+     * Create a new node after the subject
+     *
+     * @return void
+     */
+    public function apply()
+    {
+        if ($this->canApply()) {
+            $subject = $this->getSubject();
+            $parent = $subject->findParentNode();
+            $node = $this->createNode($parent);
+
+            $node->moveBefore($subject);
+            $this->updateWorkspaceInfo();
+        }
+    }
+}

--- a/Neos.EventSourcedNeosAdjustments/Classes/Ui/Domain/Model/Changes/Property.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/Ui/Domain/Model/Changes/Property.php
@@ -12,19 +12,17 @@ namespace Neos\EventSourcedNeosAdjustments\Ui\Domain\Model\Changes;
  */
 
 use Neos\ContentRepository\Domain\Model\NodeType;
-use Neos\ContentRepository\Domain\Projection\Content\NodeInterface;
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
 use Neos\ContentRepository\Domain\Service\NodeServiceInterface;
 use Neos\EventSourcedContentRepository\Domain\Context\Node\Command\SetNodeProperty;
 use Neos\EventSourcedContentRepository\Domain\Context\Node\NodeCommandHandler;
-use Neos\EventSourcedContentRepository\Domain\Context\Parameters\VisibilityConstraints;
-use Neos\EventSourcedContentRepository\Domain\Projection\Content\ContentGraphInterface;
 use Neos\EventSourcedContentRepository\Domain\ValueObject\PropertyValue;
 use Neos\EventSourcedNeosAdjustments\Ui\Domain\Model\AbstractChange;
+use Neos\EventSourcedNeosAdjustments\Ui\Domain\Model\Feedback\Operations\ReloadContentOutOfBand;
 use Neos\EventSourcedNeosAdjustments\Ui\Domain\Model\Feedback\Operations\UpdateNodeInfo;
 use Neos\EventSourcedNeosAdjustments\Ui\Service\NodePropertyConversionService;
 use Neos\Flow\Annotations as Flow;
 use Neos\ContentRepository\Domain\Service\NodeTypeManager;
-use Neos\Neos\Ui\Domain\Model\Feedback\Operations\ReloadContentOutOfBand;
 use Neos\Neos\Ui\Domain\Model\RenderedNodeDomAddress;
 use Neos\Utility\ObjectAccess;
 
@@ -85,12 +83,6 @@ class Property extends AbstractChange
      * @var NodeCommandHandler
      */
     protected $nodeCommandHandler;
-
-    /**
-     * @Flow\Inject
-     * @var ContentGraphInterface
-     */
-    protected $contentGraph;
 
     /**
      * Set the property name
@@ -228,8 +220,8 @@ class Property extends AbstractChange
 
             $reloadIfChangedConfigurationPath = sprintf('properties.%s.ui.reloadIfChanged', $propertyName);
             if (!$this->getIsInline() && $node->getNodeType()->getConfiguration($reloadIfChangedConfigurationPath)) {
-                $subgraph = $this->contentGraph->getSubgraphByIdentifier($node->getContentStreamIdentifier(), $node->getDimensionSpacePoint(), VisibilityConstraints::withoutRestrictions());
-                if ($this->getNodeDomAddress() && $this->getNodeDomAddress()->getFusionPath() && $subgraph->findParentNode($node->getNodeAggregateIdentifier())->getNodeType()->isOfType('Neos.Neos:ContentCollection')) {
+
+                if ($this->getNodeDomAddress() && $this->getNodeDomAddress()->getFusionPath() && $node->findParentNode()->getNodeType()->isOfType('Neos.Neos:ContentCollection')) {
                     $reloadContentOutOfBand = new ReloadContentOutOfBand();
                     $reloadContentOutOfBand->setNode($node);
                     $reloadContentOutOfBand->setNodeDomAddress($this->getNodeDomAddress());
@@ -252,11 +244,11 @@ class Property extends AbstractChange
     }
 
     /**
-     * @param NodeInterface $node
+     * @param TraversableNodeInterface $node
      * @param NodeType $nodeType
-     * @return NodeInterface
+     * @return TraversableNodeInterface
      */
-    protected function changeNodeType(NodeInterface $node, NodeType $nodeType)
+    protected function changeNodeType(TraversableNodeInterface $node, NodeType $nodeType)
     {
         $oldNodeType = $node->getNodeType();
         ObjectAccess::setProperty($node, 'nodeType', $nodeType);

--- a/Neos.EventSourcedNeosAdjustments/Classes/Ui/Domain/Model/Changes/Property.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/Ui/Domain/Model/Changes/Property.php
@@ -220,7 +220,6 @@ class Property extends AbstractChange
 
             $reloadIfChangedConfigurationPath = sprintf('properties.%s.ui.reloadIfChanged', $propertyName);
             if (!$this->getIsInline() && $node->getNodeType()->getConfiguration($reloadIfChangedConfigurationPath)) {
-
                 if ($this->getNodeDomAddress() && $this->getNodeDomAddress()->getFusionPath() && $node->findParentNode()->getNodeType()->isOfType('Neos.Neos:ContentCollection')) {
                     $reloadContentOutOfBand = new ReloadContentOutOfBand();
                     $reloadContentOutOfBand->setNode($node);

--- a/Neos.EventSourcedNeosAdjustments/Classes/Ui/Domain/Model/Feedback/Operations/ReloadContentOutOfBand.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/Ui/Domain/Model/Feedback/Operations/ReloadContentOutOfBand.php
@@ -1,0 +1,180 @@
+<?php
+namespace Neos\EventSourcedNeosAdjustments\Ui\Domain\Model\Feedback\Operations;
+
+/*
+ * This file is part of the Neos.Neos.Ui package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
+use Neos\EventSourcedNeosAdjustments\Domain\Context\Content\NodeAddressFactory;
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Mvc\Controller\ControllerContext;
+use Neos\Fusion\Core\Cache\ContentCache;
+use Neos\Fusion\Exception as FusionException;
+use Neos\Neos\Ui\Domain\Model\AbstractFeedback;
+use Neos\Neos\Ui\Domain\Model\FeedbackInterface;
+use Neos\Neos\Ui\Domain\Model\RenderedNodeDomAddress;
+use Neos\Neos\View\FusionView as FusionView;
+
+class ReloadContentOutOfBand extends AbstractFeedback
+{
+
+    /**
+     * @var TraversableNodeInterface
+     */
+    protected $node;
+
+    /**
+     * The node dom address
+     *
+     * @var RenderedNodeDomAddress
+     */
+    protected $nodeDomAddress;
+
+    /**
+     * @Flow\Inject
+     * @var ContentCache
+     */
+    protected $contentCache;
+
+    /**
+     * @Flow\Inject
+     * @var NodeAddressFactory
+     */
+    protected $nodeAddressFactory;
+
+    /**
+     * Set the node
+     *
+     * @param TraversableNodeInterface $node
+     * @return void
+     */
+    public function setNode(TraversableNodeInterface $node)
+    {
+        $this->node = $node;
+    }
+
+    /**
+     * Get the node
+     *
+     * @return TraversableNodeInterface
+     */
+    public function getNode()
+    {
+        return $this->node;
+    }
+
+    /**
+     * Set the node dom address
+     *
+     * @param RenderedNodeDomAddress $nodeDomAddress
+     * @return void
+     */
+    public function setNodeDomAddress(RenderedNodeDomAddress $nodeDomAddress = null)
+    {
+        $this->nodeDomAddress = $nodeDomAddress;
+    }
+
+    /**
+     * Get the node dom address
+     *
+     * @return RenderedNodeDomAddress
+     */
+    public function getNodeDomAddress()
+    {
+        return $this->nodeDomAddress;
+    }
+
+    /**
+     * Get the type identifier
+     *
+     * @return string
+     */
+    public function getType()
+    {
+        return 'Neos.Neos.Ui:ReloadContentOutOfBand';
+    }
+
+    /**
+     * Get the description
+     *
+     * @return string
+     */
+    public function getDescription()
+    {
+        return sprintf('Rendering of node "%s" required.', $this->getNode()->getPath());
+    }
+
+    /**
+     * Checks whether this feedback is similar to another
+     *
+     * @param FeedbackInterface $feedback
+     * @return boolean
+     */
+    public function isSimilarTo(FeedbackInterface $feedback)
+    {
+        if (!$feedback instanceof ReloadContentOutOfBand) {
+            return false;
+        }
+
+        return (
+            (string)$this->getNode()->getContentStreamIdentifier() === (string)$feedback->getNode()->getContentStreamIdentifier() &&
+            $this->getNode()->getDimensionSpacePoint()->getHash() === $feedback->getNode()->getDimensionSpacePoint()->getHash() &&
+            (string)$this->getNode()->getNodeAggregateIdentifier() === (string)$feedback->getNode()->getNodeAggregateIdentifier() &&
+
+            $this->getNodeDomAddress() == $feedback->getNodeDomAddress()
+        );
+    }
+
+    /**
+     * Serialize the payload for this feedback
+     *
+     * @return mixed
+     */
+    public function serializePayload(ControllerContext $controllerContext)
+    {
+        return [
+            'contextPath' => $this->nodeAddressFactory->createFromNode($this->getNode())->serializeForUri(),
+            'nodeDomAddress' => $this->getNodeDomAddress(),
+            'renderedContent' => $this->renderContent($controllerContext)
+        ];
+    }
+
+    /**
+     * Render the node
+     *
+     * @param ControllerContext $controllerContext
+     * @return string
+     */
+    protected function renderContent(ControllerContext $controllerContext)
+    {
+        $this->contentCache->flushByTag(sprintf('Node_%s', (string)$this->getNode()->getNodeAggregateIdentifier()));
+
+        $nodeDomAddress = $this->getNodeDomAddress();
+
+        $fusionView = new FusionView();
+        $fusionView->setControllerContext($controllerContext);
+
+        $fusionView->assign('value', $this->getNode());
+        $fusionView->setFusionPath($nodeDomAddress->getFusionPath());
+
+        return $fusionView->render();
+    }
+
+    public function serialize(ControllerContext $controllerContext)
+    {
+        try {
+            return parent::serialize($controllerContext);
+        } catch (FusionException $e) {
+            // in case there was a rendering error, we just try to reload the document as fallback. Needed
+            // e.g. when adding validators to Neos.FormBuilder
+            return (new ReloadDocument())->serialize($controllerContext);
+        }
+    }
+}

--- a/Neos.EventSourcedNeosAdjustments/Classes/Ui/Domain/Model/Feedback/Operations/RenderContentOutOfBand.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/Ui/Domain/Model/Feedback/Operations/RenderContentOutOfBand.php
@@ -1,0 +1,235 @@
+<?php
+namespace Neos\EventSourcedNeosAdjustments\Ui\Domain\Model\Feedback\Operations;
+
+/*
+ * This file is part of the Neos.Neos.Ui package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
+use Neos\EventSourcedNeosAdjustments\Domain\Context\Content\NodeAddressFactory;
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Mvc\Controller\ControllerContext;
+use Neos\Fusion\Core\Cache\ContentCache;
+use Neos\Fusion\Exception as FusionException;
+use Neos\Neos\Ui\Domain\Model\AbstractFeedback;
+use Neos\Neos\Ui\Domain\Model\FeedbackInterface;
+use Neos\Neos\Ui\Domain\Model\RenderedNodeDomAddress;
+use Neos\Neos\View\FusionView as FusionView;
+
+class RenderContentOutOfBand extends AbstractFeedback
+{
+    /**
+     * @var TraversableNodeInterface
+     */
+    protected $node;
+
+    /**
+     * The node dom address for the parent node of the created node
+     *
+     * @var RenderedNodeDomAddress
+     */
+    protected $parentDomAddress;
+
+    /**
+     * The node dom address for the referenced sibling node of the created node
+     *
+     * @var RenderedNodeDomAddress
+     */
+    protected $siblingDomAddress;
+
+    /**
+     * @var string
+     */
+    protected $mode;
+
+    /**
+     * @Flow\Inject
+     * @var ContentCache
+     */
+    protected $contentCache;
+
+    /**
+     * @Flow\Inject
+     * @var NodeAddressFactory
+     */
+    protected $nodeAddressFactory;
+
+    /**
+     * Set the node
+     *
+     * @param TraversableNodeInterface $node
+     * @return void
+     */
+    public function setNode(TraversableNodeInterface $node)
+    {
+        $this->node = $node;
+    }
+
+    /**
+     * Get the node
+     *
+     * @return TraversableNodeInterface
+     */
+    public function getNode()
+    {
+        return $this->node;
+    }
+
+    /**
+     * Set the parent node dom address
+     *
+     * @param RenderedNodeDomAddress $parentDomAddress
+     * @return void
+     */
+    public function setParentDomAddress(RenderedNodeDomAddress $parentDomAddress = null)
+    {
+        $this->parentDomAddress = $parentDomAddress;
+    }
+
+    /**
+     * Get the parent node dom address
+     *
+     * @return RenderedNodeDomAddress
+     */
+    public function getParentDomAddress()
+    {
+        return $this->parentDomAddress;
+    }
+
+    /**
+     * Set the sibling node dom address
+     *
+     * @param RenderedNodeDomAddress $siblingDomAddress
+     * @return void
+     */
+    public function setSiblingDomAddress(RenderedNodeDomAddress $siblingDomAddress = null)
+    {
+        $this->siblingDomAddress = $siblingDomAddress;
+    }
+
+    /**
+     * Get the sibling node dom address
+     *
+     * @return RenderedNodeDomAddress
+     */
+    public function getSiblingDomAddress()
+    {
+        return $this->siblingDomAddress;
+    }
+
+    /**
+     * Set the insertion mode (before|after|into)
+     *
+     * @param string $mode
+     * @return void
+     */
+    public function setMode($mode)
+    {
+        $this->mode = $mode;
+    }
+
+    /**
+     * Get the insertion mode (before|after|into)
+     *
+     * @return string
+     */
+    public function getMode()
+    {
+        return $this->mode;
+    }
+
+    /**
+     * Get the type identifier
+     *
+     * @return string
+     */
+    public function getType()
+    {
+        return 'Neos.Neos.Ui:RenderContentOutOfBand';
+    }
+
+    /**
+     * Get the description
+     *
+     * @return string
+     */
+    public function getDescription()
+    {
+        return sprintf('Rendering of node "%s" required.', $this->getNode()->getNodeAggregateIdentifier());
+    }
+
+    /**
+     * Checks whether this feedback is similar to another
+     *
+     * @param FeedbackInterface $feedback
+     * @return boolean
+     */
+    public function isSimilarTo(FeedbackInterface $feedback)
+    {
+        if (!$feedback instanceof RenderContentOutOfBand) {
+            return false;
+        }
+
+        return (
+            (string)$this->getNode()->getContentStreamIdentifier() === (string)$feedback->getNode()->getContentStreamIdentifier() &&
+            $this->getNode()->getDimensionSpacePoint()->getHash() === $feedback->getNode()->getDimensionSpacePoint()->getHash() &&
+            (string)$this->getNode()->getNodeAggregateIdentifier() === (string)$feedback->getNode()->getNodeAggregateIdentifier() &&
+
+            $this->getReferenceData() == $feedback->getReferenceData()
+        );
+    }
+
+    /**
+     * Serialize the payload for this feedback
+     *
+     * @return mixed
+     */
+    public function serializePayload(ControllerContext $controllerContext)
+    {
+        return [
+            'contextPath' => $this->nodeAddressFactory->createFromNode($this->getNode())->serializeForUri(),
+            'parentDomAddress' => $this->getParentDomAddress(),
+            'siblingDomAddress' => $this->getSiblingDomAddress(),
+            'mode' => $this->getMode(),
+            'renderedContent' => $this->renderContent($controllerContext)
+        ];
+    }
+
+    /**
+     * Render the node
+     *
+     * @param ControllerContext $controllerContext
+     * @return string
+     */
+    protected function renderContent(ControllerContext $controllerContext)
+    {
+        $this->contentCache->flushByTag(sprintf('Node_%s', (string)$this->getNode()->findParentNode()->getNodeAggregateIdentifier()));
+
+        $parentDomAddress = $this->getParentDomAddress();
+
+        $fusionView = new FusionView();
+        $fusionView->setControllerContext($controllerContext);
+
+        $fusionView->assign('value', $this->getNode()->findParentNode());
+        $fusionView->setFusionPath($parentDomAddress->getFusionPath());
+
+        return $fusionView->render();
+    }
+
+    public function serialize(ControllerContext $controllerContext)
+    {
+        try {
+            return parent::serialize($controllerContext);
+        } catch (FusionException $e) {
+            // in case there was a rendering error, we just try to reload the document as fallback. Needed
+            // e.g. when adding validators to Neos.FormBuilder
+            return (new ReloadDocument())->serialize($controllerContext);
+        }
+    }
+}

--- a/Neos.EventSourcedNeosAdjustments/Classes/Ui/Domain/Model/Feedback/Operations/UpdateNodeInfo.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/Ui/Domain/Model/Feedback/Operations/UpdateNodeInfo.php
@@ -11,9 +11,8 @@ namespace Neos\EventSourcedNeosAdjustments\Ui\Domain\Model\Feedback\Operations;
  * source code.
  */
 
-use Neos\ContentRepository\Domain\Projection\Content\NodeInterface;
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
 use Neos\EventSourcedContentRepository\Domain\Context\Parameters\VisibilityConstraints;
-use Neos\EventSourcedContentRepository\Domain\Projection\Content\ContentGraphInterface;
 use Neos\EventSourcedNeosAdjustments\Domain\Context\Content\NodeAddressFactory;
 use Neos\EventSourcedNeosAdjustments\Ui\Fusion\Helper\NodeInfoHelper;
 use Neos\Flow\Annotations as Flow;
@@ -24,7 +23,7 @@ use Neos\Flow\Mvc\Controller\ControllerContext;
 class UpdateNodeInfo extends AbstractFeedback
 {
     /**
-     * @var NodeInterface
+     * @var TraversableNodeInterface
      */
     protected $node;
 
@@ -33,13 +32,6 @@ class UpdateNodeInfo extends AbstractFeedback
      * @var NodeInfoHelper
      */
     protected $nodeInfoHelper;
-
-    /**
-     * @Flow\Inject
-     * @var ContentGraphInterface
-     */
-    protected $contentGraph;
-
 
     /**
      * @Flow\Inject
@@ -52,10 +44,10 @@ class UpdateNodeInfo extends AbstractFeedback
     /**
      * Set the node
      *
-     * @param NodeInterface $node
+     * @param TraversableNodeInterface $node
      * @return void
      */
-    public function setNode(NodeInterface $node)
+    public function setNode(TraversableNodeInterface $node)
     {
         $this->node = $node;
     }
@@ -73,7 +65,7 @@ class UpdateNodeInfo extends AbstractFeedback
     /**
      * Get the node
      *
-     * @return NodeInterface
+     * @return TraversableNodeInterface
      */
     public function getNode()
     {
@@ -131,20 +123,18 @@ class UpdateNodeInfo extends AbstractFeedback
     /**
      * Serialize node and all child nodes
      *
-     * @param NodeInterface $node
+     * @param TraversableNodeInterface $node
      * @param ControllerContext $controllerContext
      * @return array
      */
-    public function serializeNodeRecursively(NodeInterface $node, ControllerContext $controllerContext)
+    public function serializeNodeRecursively(TraversableNodeInterface $node, ControllerContext $controllerContext)
     {
-        $subgraph = $this->contentGraph->getSubgraphByIdentifier($node->getContentStreamIdentifier(), $node->getDimensionSpacePoint(), VisibilityConstraints::withoutRestrictions());
-
         $result = [
             $this->nodeAddressFactory->createFromNode($node)->serializeForUri() => $this->nodeInfoHelper->renderNodeWithPropertiesAndChildrenInformation($node, $controllerContext)
         ];
 
         if ($this->isRecursive === true) {
-            foreach ($subgraph->findChildNodes($node->getNodeAggregateIdentifier()) as $childNode) {
+            foreach ($node->findChildNodes() as $childNode) {
                 $result = array_merge($result, $this->serializeNodeRecursively($childNode, $controllerContext));
             }
         }

--- a/Neos.EventSourcedNeosAdjustments/Classes/Ui/Domain/Model/Feedback/Operations/UpdateNodeInfo.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/Ui/Domain/Model/Feedback/Operations/UpdateNodeInfo.php
@@ -12,7 +12,6 @@ namespace Neos\EventSourcedNeosAdjustments\Ui\Domain\Model\Feedback\Operations;
  */
 
 use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
-use Neos\EventSourcedContentRepository\Domain\Context\Parameters\VisibilityConstraints;
 use Neos\EventSourcedNeosAdjustments\Domain\Context\Content\NodeAddressFactory;
 use Neos\EventSourcedNeosAdjustments\Ui\Fusion\Helper\NodeInfoHelper;
 use Neos\Flow\Annotations as Flow;

--- a/Neos.EventSourcedNeosAdjustments/Classes/Ui/Fusion/Helper/NodeInfoHelper.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/Ui/Fusion/Helper/NodeInfoHelper.php
@@ -12,6 +12,7 @@ namespace Neos\EventSourcedNeosAdjustments\Ui\Fusion\Helper;
  */
 
 use Neos\ContentRepository\Domain\Factory\NodeTypeConstraintFactory;
+use Neos\ContentRepository\Domain\Model\NodeType;
 use Neos\ContentRepository\Domain\Projection\Content\NodeInterface;
 use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
 use Neos\Eel\ProtectedContextAwareInterface;
@@ -241,6 +242,15 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
             }
         }
         return false;
+    }
+
+    public static function isNodeTypeAllowedAsChildNode(TraversableNodeInterface $node, NodeType $nodeType)
+    {
+        if (self::isAutoCreated($node)) {
+            return $node->findParentNode()->getNodeType()->allowsGrandchildNodeType((string)$node->getNodeName(), $nodeType);
+        } else {
+            return $node->getNodeType()->allowsChildNodeType($nodeType);
+        }
     }
 
 

--- a/Neos.EventSourcedNeosAdjustments/Classes/Ui/NodeCreationHandler/DocumentTitleNodeCreationHandler.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/Ui/NodeCreationHandler/DocumentTitleNodeCreationHandler.php
@@ -1,0 +1,66 @@
+<?php
+namespace Neos\EventSourcedNeosAdjustments\Ui\NodeCreationHandler;
+
+/*
+ * This file is part of the Neos.Neos.Ui package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
+use Neos\EventSourcedContentRepository\Domain\Context\Node\Command\SetNodeProperty;
+use Neos\EventSourcedContentRepository\Domain\Context\Node\NodeCommandHandler;
+use Neos\EventSourcedContentRepository\Domain\ValueObject\PropertyValue;
+use Neos\Flow\Annotations as Flow;
+use Neos\Neos\Utility\NodeUriPathSegmentGenerator;
+
+class DocumentTitleNodeCreationHandler implements NodeCreationHandlerInterface
+{
+    /**
+     * @Flow\Inject
+     * @var NodeUriPathSegmentGenerator
+     */
+    protected $nodeUriPathSegmentGenerator;
+
+    /**
+     * @Flow\Inject
+     * @var NodeCommandHandler
+     */
+    protected $nodeCommandHandler;
+
+    /**
+     * Set the node title for the newly created Document node
+     *
+     * @param TraversableNodeInterface $node The newly created node
+     * @param array $data incoming data from the creationDialog
+     * @return void
+     */
+    public function handle(TraversableNodeInterface $node, array $data)
+    {
+        if ($node->getNodeType()->isOfType('Neos.Neos:Document')) {
+            if (isset($data['title'])) {
+                $this->nodeCommandHandler->handleSetNodeProperty(new SetNodeProperty(
+                    $node->getContentStreamIdentifier(),
+                    $node->getNodeAggregateIdentifier(),
+                    $node->getOriginDimensionSpacePoint(),
+                    'title',
+                    new PropertyValue($data['title'], 'string')
+                ));
+            }
+
+            $this->nodeCommandHandler->handleSetNodeProperty(new SetNodeProperty(
+                $node->getContentStreamIdentifier(),
+                $node->getNodeAggregateIdentifier(),
+                $node->getOriginDimensionSpacePoint(),
+                'uriPathSegment',
+                new PropertyValue($data['title'], 'string')
+            ));
+            // TODO: re-enable line below
+            // $node->setProperty('uriPathSegment', $this->nodeUriPathSegmentGenerator->generateUriPathSegment($node, (isset($data['title']) ? $data['title'] : null)));
+        }
+    }
+}

--- a/Neos.EventSourcedNeosAdjustments/Classes/Ui/NodeCreationHandler/NodeCreationHandlerInterface.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/Ui/NodeCreationHandler/NodeCreationHandlerInterface.php
@@ -1,0 +1,29 @@
+<?php
+namespace Neos\EventSourcedNeosAdjustments\Ui\NodeCreationHandler;
+
+/*
+ * This file is part of the Neos.Neos.Ui package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
+
+/**
+ * NodeTypePostprocessorInterface
+ */
+interface NodeCreationHandlerInterface
+{
+    /**
+     * Do something with the newly created node
+     *
+     * @param TraversableNodeInterface $node The newly created node
+     * @param array $data incoming data from the creationDialog
+     * @return void
+     */
+    public function handle(TraversableNodeInterface $node, array $data);
+}

--- a/Neos.EventSourcedNeosAdjustments/Configuration/NodeTypes.yaml
+++ b/Neos.EventSourcedNeosAdjustments/Configuration/NodeTypes.yaml
@@ -17,3 +17,7 @@
 'Neos.Neos:Document':
   properties:
     _hiddenInIndex: ~
+  options:
+    nodeCreationHandlers:
+      documentTitle:
+        nodeCreationHandler: 'Neos\EventSourcedNeosAdjustments\Ui\NodeCreationHandler\DocumentTitleNodeCreationHandler'

--- a/Neos.EventSourcedNeosAdjustments/Configuration/Settings.yaml
+++ b/Neos.EventSourcedNeosAdjustments/Configuration/Settings.yaml
@@ -75,3 +75,6 @@ Neos:
       changes:
         types:
           'Neos.Neos.Ui:Property': Neos\EventSourcedNeosAdjustments\Ui\Domain\Model\Changes\Property
+          'Neos.Neos.Ui:CreateInto': Neos\EventSourcedNeosAdjustments\Ui\Domain\Model\Changes\Create
+          'Neos.Neos.Ui:CreateAfter': Neos\EventSourcedNeosAdjustments\Ui\Domain\Model\Changes\CreateAfter
+          'Neos.Neos.Ui:CreateBefore': Neos\EventSourcedNeosAdjustments\Ui\Domain\Model\Changes\CreateBefore


### PR DESCRIPTION
- [ ] basic "Create into" behavior for document nodes
  - [ ] "Create Into" for content nodes
- [ ] Changes\Create() should generate a unique node name using `$this->nodeService->generateUniqueNodeName($parent->findParentNode())` (see TODO)
- [ ] implement "Create After" for document nodes
  - [ ] "Create after" for content nodes
- [ ] implement "Create Before" for document nodes
  - [ ] "Create before" for content nodes
- [ ] `DocumentTitleNodeCreationHandler`: re-enable nodeUriPathSegmentGenerator (see TODO inside)