### PR TITLE
Fix references and backend node search

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/Classes/Domain/Repository/ContentSubgraph.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Classes/Domain/Repository/ContentSubgraph.php
@@ -145,8 +145,7 @@ final class ContentSubgraph implements ContentSubgraphInterface
         string $markerToReplaceInQuery = null,
         string $tableReference = 'c',
         string $concatenation = 'AND'
-    ): void
-    {
+    ): void {
         if ($searchTerm) {
             // Magic copied from legacy NodeSearchService.
 

--- a/Neos.EventSourcedContentRepository/Classes/Domain/Projection/Content/ContentSubgraphInterface.php
+++ b/Neos.EventSourcedContentRepository/Classes/Domain/Projection/Content/ContentSubgraphInterface.php
@@ -135,11 +135,16 @@ interface ContentSubgraphInterface extends \JsonSerializable
     public function findSubtrees(array $entryNodeAggregateIdentifiers, int $maximumLevels, NodeTypeConstraints $nodeTypeConstraints): SubtreeInterface;
 
     /**
+     * Recursively find all nodes underneath the $entryNodeAggregateIdentifiers, which match the node type constraints specified by NodeTypeConstraints.
+     *
+     * If a Search Term is specified, the properties are searched for this search term.
+     *
      * @param array $entryNodeAggregateIdentifiers
      * @param NodeTypeConstraints $nodeTypeConstraints
+     * @param SearchTerm|null $searchTerm
      * @return array|NodeInterface[]
      */
-    public function findDescendants(array $entryNodeAggregateIdentifiers, NodeTypeConstraints $nodeTypeConstraints): array;
+    public function findDescendants(array $entryNodeAggregateIdentifiers, NodeTypeConstraints $nodeTypeConstraints, ?SearchTerm $searchTerm): array;
 
     public function countNodes(): int;
 

--- a/Neos.EventSourcedContentRepository/Classes/Domain/Projection/Content/SearchTerm.php
+++ b/Neos.EventSourcedContentRepository/Classes/Domain/Projection/Content/SearchTerm.php
@@ -29,7 +29,7 @@ final class SearchTerm
      * @param string $term
      * @return SearchTerm
      */
-    static public function fulltext(string $term): self
+    public static function fulltext(string $term): self
     {
         return new SearchTerm($term);
     }

--- a/Neos.EventSourcedContentRepository/Classes/Domain/Projection/Content/SearchTerm.php
+++ b/Neos.EventSourcedContentRepository/Classes/Domain/Projection/Content/SearchTerm.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\EventSourcedContentRepository\Domain\Projection\Content;
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * A search term for use in {@see ContentSubgraphInterface::findDescendants()} API.
+ *
+ * @Flow\Proxy(false)
+ */
+final class SearchTerm
+{
+
+    /**
+     * Create a new Fulltext search term (i.e. search across all properties)
+     *
+     * @param string $term
+     * @return SearchTerm
+     */
+    static public function fulltext(string $term): self
+    {
+        return new SearchTerm($term);
+    }
+
+    /**
+     * @var string
+     */
+    private $term;
+
+    private function __construct(string $term)
+    {
+        $this->term = $term;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTerm(): string
+    {
+        return $this->term;
+    }
+}

--- a/Neos.EventSourcedNeosAdjustments/Classes/Eel/FlowQueryOperations/FilterOperation.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/Eel/FlowQueryOperations/FilterOperation.php
@@ -12,10 +12,7 @@ namespace Neos\EventSourcedNeosAdjustments\Eel\FlowQueryOperations;
  */
 
 use Neos\ContentRepository\Domain\Projection\Content\NodeInterface;
-use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
-use Neos\Eel\FlowQuery\FlowQuery;
 use Neos\Utility\ObjectAccess;
-use Neos\ContentRepository\Domain\Model\Node;
 
 /**
  * This filter implementation contains specific behavior for use on ContentRepository

--- a/Neos.EventSourcedNeosAdjustments/Classes/Eel/FlowQueryOperations/FindOperation.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/Eel/FlowQueryOperations/FindOperation.php
@@ -13,7 +13,7 @@ namespace Neos\EventSourcedNeosAdjustments\Eel\FlowQueryOperations;
 
 use Neos\ContentRepository\Domain\ContentSubgraph\NodePath;
 use Neos\ContentRepository\Domain\NodeAggregate\NodeAggregateIdentifier;
-use Neos\ContentRepository\Domain\NodeType\NodeTypeConstraints;
+use Neos\ContentRepository\Domain\NodeType\NodeTypeConstraintFactory;
 use Neos\ContentRepository\Domain\NodeType\NodeTypeName;
 use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
 use Neos\ContentRepository\Domain\Projection\Content\TraversableNodes;
@@ -82,6 +82,12 @@ class FindOperation extends AbstractOperation
      * @var ContentGraphInterface
      */
     protected $contentGraph;
+
+    /**
+     * @Flow\Inject
+     * @var NodeTypeConstraintFactory
+     */
+    protected $nodeTypeConstraintFactory;
 
     /**
      * {@inheritdoc}
@@ -244,7 +250,7 @@ class FindOperation extends AbstractOperation
                 return $node->getNodeAggregateIdentifier();
             }, $entryPoint['nodes']);
 
-            foreach ($subgraph->findDescendants($entryIdentifiers, new NodeTypeConstraints(false, [$nodeTypeName])) as $descendant) {
+            foreach ($subgraph->findDescendants($entryIdentifiers, $this->nodeTypeConstraintFactory->parseFilterString($nodeTypeName->jsonSerialize())) as $descendant) {
                 $result[] = new TraversableNode($descendant, $subgraph);
             }
         }

--- a/Neos.EventSourcedNeosAdjustments/Classes/Eel/FlowQueryOperations/FindOperation.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/Eel/FlowQueryOperations/FindOperation.php
@@ -250,7 +250,7 @@ class FindOperation extends AbstractOperation
                 return $node->getNodeAggregateIdentifier();
             }, $entryPoint['nodes']);
 
-            foreach ($subgraph->findDescendants($entryIdentifiers, $this->nodeTypeConstraintFactory->parseFilterString($nodeTypeName->jsonSerialize())) as $descendant) {
+            foreach ($subgraph->findDescendants($entryIdentifiers, $this->nodeTypeConstraintFactory->parseFilterString($nodeTypeName->jsonSerialize()), null) as $descendant) {
                 $result[] = new TraversableNode($descendant, $subgraph);
             }
         }

--- a/Neos.EventSourcedNeosAdjustments/Classes/Fluid/ViewHelperReplacementAspect.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/Fluid/ViewHelperReplacementAspect.php
@@ -31,7 +31,8 @@ class ViewHelperReplacementAspect
         \Neos\Neos\ViewHelpers\Rendering\InEditModeViewHelper::class => \Neos\EventSourcedNeosAdjustments\Fluid\ViewHelpers\Rendering\InEditModeViewHelper::class,
         \Neos\Neos\ViewHelpers\Rendering\InPreviewModeViewHelper::class => \Neos\EventSourcedNeosAdjustments\Fluid\ViewHelpers\Rendering\InPreviewModeViewHelper::class,
         \Neos\Neos\ViewHelpers\Rendering\LiveViewHelper::class => \Neos\EventSourcedNeosAdjustments\Fluid\ViewHelpers\Rendering\LiveViewHelper::class,
-        \Neos\Neos\ViewHelpers\Backend\DocumentBreadcrumbPathViewHelper::class => \Neos\EventSourcedNeosAdjustments\Fluid\ViewHelpers\Backend\DocumentBreadcrumbPathViewHelper::class
+        \Neos\Neos\ViewHelpers\Backend\DocumentBreadcrumbPathViewHelper::class => \Neos\EventSourcedNeosAdjustments\Fluid\ViewHelpers\Backend\DocumentBreadcrumbPathViewHelper::class,
+        \Neos\Neos\ViewHelpers\Node\ClosestDocumentViewHelper::class => \Neos\EventSourcedNeosAdjustments\Fluid\ViewHelpers\Node\ClosestDocumentViewHelper::class
 
     ];
 

--- a/Neos.EventSourcedNeosAdjustments/Classes/Fluid/ViewHelpers/Node/ClosestDocumentViewHelper.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/Fluid/ViewHelpers/Node/ClosestDocumentViewHelper.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+namespace Neos\EventSourcedNeosAdjustments\Fluid\ViewHelpers\Node;
+
+/*
+ * This file is part of the Neos.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
+use Neos\FluidAdaptor\Core\ViewHelper\AbstractViewHelper;
+use Neos\Eel\FlowQuery\FlowQuery;
+
+/**
+ * ViewHelper to find the closest document node to a given node
+ */
+class ClosestDocumentViewHelper extends AbstractViewHelper
+{
+    /**
+     * @param TraversableNodeInterface $node
+     * @return TraversableNodeInterface
+     */
+    public function render(TraversableNodeInterface $node)
+    {
+        $flowQuery = new FlowQuery([$node]);
+        return $flowQuery->closest('[instanceof Neos.Neos:Document]')->get(0);
+    }
+}

--- a/Neos.EventSourcedNeosAdjustments/Classes/ServiceControllers/NodesControllerAspect.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/ServiceControllers/NodesControllerAspect.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\EventSourcedNeosAdjustments\ServiceControllers;
+
+/*
+ * This file is part of the Neos.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Aop\JoinPointInterface;
+
+/**
+ * @Flow\Scope("singleton")
+ * @Flow\Aspect
+ */
+class NodesControllerAspect
+{
+
+    /**
+     * Hooks into standard content element wrapping to render those attributes needed for the package to identify
+     * nodes and Fusion paths
+     *
+     * @Flow\Around("method(Neos\Neos\Controller\Service\NodesController->processRequest())")
+     * @param JoinPointInterface $joinPoint the join point
+     * @return mixed
+     */
+    public function replaceNodesController(JoinPointInterface $joinPoint)
+    {
+        $controller = new ServiceNodesController();
+        $controller->processRequest($joinPoint->getMethodArgument('request'), $joinPoint->getMethodArgument('response'));
+    }
+}

--- a/Neos.EventSourcedNeosAdjustments/Classes/ServiceControllers/ServiceNodesController.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/ServiceControllers/ServiceNodesController.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Neos\EventSourcedNeosAdjustments\ServiceControllers;
+
+/*
+ * This file is part of the Neos.Neos package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\ContentRepository\Domain\NodeAggregate\NodeAggregateIdentifier;
+use Neos\ContentRepository\Domain\NodeType\NodeTypeConstraintFactory;
+use Neos\EventSourcedContentRepository\Domain\Context\Parameters\VisibilityConstraints;
+use Neos\EventSourcedContentRepository\Domain\Projection\Content\ContentGraphInterface;
+use Neos\EventSourcedContentRepository\Domain\Projection\Content\SearchTerm;
+use Neos\EventSourcedContentRepository\Domain\Projection\Content\TraversableNode;
+use Neos\EventSourcedNeosAdjustments\Domain\Context\Content\NodeAddress;
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Mvc\Controller\ActionController;
+use Neos\Flow\Property\PropertyMapper;
+use Neos\FluidAdaptor\View\TemplateView;
+use Neos\Neos\Controller\BackendUserTranslationTrait;
+use Neos\Neos\Controller\CreateContentContextTrait;
+use Neos\Neos\Domain\Service\NodeSearchServiceInterface;
+use Neos\Neos\View\Service\NodeJsonView;
+use Neos\ContentRepository\Domain\Service\NodeTypeManager;
+
+/**
+ * Rudimentary REST service for nodes
+ *
+ * @Flow\Scope("singleton")
+ */
+class ServiceNodesController extends ActionController
+{
+    use BackendUserTranslationTrait;
+    use CreateContentContextTrait;
+
+    /**
+     * @Flow\Inject
+     * @var NodeTypeManager
+     */
+    protected $nodeTypeManager;
+
+    /**
+     * @Flow\Inject
+     * @var NodeSearchServiceInterface
+     */
+    protected $nodeSearchService;
+
+    /**
+     * @Flow\Inject
+     * @var PropertyMapper
+     */
+    protected $propertyMapper;
+
+    /**
+     * @Flow\Inject
+     * @var ContentGraphInterface
+     */
+    protected $contentGraph;
+    /**
+     * @Flow\Inject
+     * @var NodeTypeConstraintFactory
+     */
+    protected $nodeTypeConstraintFactory;
+
+    /**
+     * @var array
+     */
+    protected $viewFormatToObjectNameMap = [
+        'html' => TemplateView::class,
+        'json' => NodeJsonView::class
+    ];
+
+    /**
+     * A list of IANA media types which are supported by this controller
+     *
+     * @var array
+     * @see http://www.iana.org/assignments/media-types/index.html
+     */
+    protected $supportedMediaTypes = [
+        'text/html',
+        'application/json'
+    ];
+
+    /**
+     * Shows a list of nodes
+     *
+     * @param string $searchTerm An optional search term used for filtering the list of nodes
+     * @param array $nodeIdentifiers An optional list of node identifiers
+     * @param string $workspaceName Name of the workspace to search in, "live" by default
+     * @param array $dimensions Optional list of dimensions and their values which should be used for querying
+     * @param array $nodeTypes A list of node types the list should be filtered by
+     * @param NodeAddress $contextNode a node to use as context for the search
+     * @return string
+     */
+    public function indexAction($searchTerm = '', array $nodeIdentifiers = [], $workspaceName = 'live', array $dimensions = [], array $nodeTypes = ['Neos.Neos:Document'], NodeAddress $contextNode = null)
+    {
+        $nodeAddress = $contextNode;
+        unset($contextNode);
+        $subgraph = $this->contentGraph->getSubgraphByIdentifier(
+            $nodeAddress->getContentStreamIdentifier(),
+            $nodeAddress->getDimensionSpacePoint(),
+            VisibilityConstraints::withoutRestrictions() // we are in a backend controller.
+        );
+
+        $traversableNodes = [];
+
+        if ($nodeIdentifiers === []) {
+            $nodes = $subgraph->findDescendants(
+                [$nodeAddress->getNodeAggregateIdentifier()],
+                $this->nodeTypeConstraintFactory->parseFilterString(implode(',', $nodeTypes)),
+                SearchTerm::fulltext($searchTerm)
+            );
+
+            foreach ($nodes as $node) {
+                $traversableNodes[] = new TraversableNode($node, $subgraph);
+            }
+        } else {
+            if (!empty($searchTerm)) {
+                throw new \RuntimeException('Combination of $nodeIdentifiers and $searchTerm not supported');
+            }
+
+            foreach ($nodeIdentifiers as $nodeAggregateIdentifier) {
+                $node = $subgraph->findNodeByNodeAggregateIdentifier(NodeAggregateIdentifier::fromString($nodeAggregateIdentifier));
+                if ($node !== null) {
+                    $traversableNodes[] = new TraversableNode($node, $subgraph);
+                }
+            }
+        }
+
+        $this->view->assign('nodes', $traversableNodes);
+    }
+}

--- a/Neos.EventSourcedNeosAdjustments/Classes/Ui/Domain/Model/Changes/Property.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/Ui/Domain/Model/Changes/Property.php
@@ -14,15 +14,18 @@ namespace Neos\EventSourcedNeosAdjustments\Ui\Domain\Model\Changes;
 
 use Neos\ContentRepository\DimensionSpace\DimensionSpace\Exception\DimensionSpacePointNotFound;
 use Neos\ContentRepository\Domain\Model\NodeType;
+use Neos\ContentRepository\Domain\NodeAggregate\NodeAggregateIdentifier;
 use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
 use Neos\ContentRepository\Domain\Service\NodeServiceInterface;
 use Neos\EventSourcedContentRepository\Domain\Context\ContentStream\Exception\ContentStreamDoesNotExistYet;
 use Neos\EventSourcedContentRepository\Domain\Context\NodeAggregate\Command\DisableNodeAggregate;
 use Neos\EventSourcedContentRepository\Domain\Context\NodeAggregate\Command\SetNodeProperties;
 use Neos\EventSourcedContentRepository\Domain\Context\NodeAggregate\Command\EnableNodeAggregate;
+use Neos\EventSourcedContentRepository\Domain\Context\NodeAggregate\Command\SetNodeReferences;
 use Neos\EventSourcedContentRepository\Domain\Context\NodeAggregate\Exception\NodeAggregatesTypeIsAmbiguous;
 use Neos\EventSourcedContentRepository\Domain\Context\NodeAggregate\NodeAggregateCommandHandler;
 use Neos\EventSourcedContentRepository\Domain\Context\NodeAggregate\NodeVariantSelectionStrategyIdentifier;
+use Neos\EventSourcedContentRepository\Domain\ValueObject\PropertyName;
 use Neos\EventSourcedContentRepository\Domain\ValueObject\PropertyValue;
 use Neos\EventSourcedContentRepository\Domain\ValueObject\PropertyValues;
 use Neos\EventSourcedNeosAdjustments\Ui\Domain\Model\AbstractChange;
@@ -203,53 +206,85 @@ class Property extends AbstractChange
         if ($this->canApply()) {
             $node = $this->getSubject();
             $propertyName = $this->getPropertyName();
-            $value = $this->nodePropertyConversionService->convert(
-                $node->getNodeType(),
-                $propertyName,
-                $this->getValue()
-            );
 
-            // TODO: Make changing the node type a separated, specific/defined change operation.
-            if ($propertyName{0} !== '_' || $propertyName === '_hiddenInIndex') {
-                $propertyType = $this->nodeTypeManager->getNodeType((string)$node->getNodeType())->getPropertyType($propertyName);
-                $command = new SetNodeProperties(
+            $propertyType = $node->getNodeType()->getPropertyType($propertyName);
+            if ($propertyType === 'reference' || $propertyType === 'references') {
+
+                $value = $this->getValue();
+                $destinationNodeAggregateIdentifiers = [];
+                if ($propertyType === 'reference') {
+                    if (!empty($value)) {
+                        $destinationNodeAggregateIdentifiers[] = NodeAggregateIdentifier::fromString($value);
+                    }
+                }
+
+                if ($propertyType === 'references') {
+                    /** @var array $values */
+                    $values = $value;
+                    if (is_array($values)) {
+                        foreach ($values as $singleNodeAggregateIdentifier) {
+                            $destinationNodeAggregateIdentifiers[] = NodeAggregateIdentifier::fromString($singleNodeAggregateIdentifier);
+                        }
+                    }
+                }
+
+                $command = new SetNodeReferences(
                     $node->getContentStreamIdentifier(),
                     $node->getNodeAggregateIdentifier(),
                     $node->getOriginDimensionSpacePoint(),
-                    PropertyValues::fromArray(
-                        [
-                            $propertyName => new PropertyValue($value, $propertyType)
-                        ]
-                    )
+                    $destinationNodeAggregateIdentifiers,
+                    PropertyName::fromString($propertyName)
                 );
-                $this->nodeAggregateCommandHandler->handleSetNodeProperties($command)->blockUntilProjectionsAreUpToDate();
+                $this->nodeAggregateCommandHandler->handleSetNodeReferences($command)->blockUntilProjectionsAreUpToDate();
             } else {
-                // property starts with "_"
-                if ($propertyName === '_nodeType') {
-                    throw new \Exception("TODO FIX");
-                    $nodeType = $this->nodeTypeManager->getNodeType($value);
-                    $node = $this->changeNodeType($node, $nodeType);
-                } elseif ($propertyName === '_hidden') {
-                    if ($value === true) {
-                        $command = new DisableNodeAggregate(
-                            $node->getContentStreamIdentifier(),
-                            $node->getNodeAggregateIdentifier(),
-                            $node->getOriginDimensionSpacePoint(),
-                            NodeVariantSelectionStrategyIdentifier::allSpecializations()
-                        );
-                        $this->nodeAggregateCommandHandler->handleDisableNodeAggregate($command)->blockUntilProjectionsAreUpToDate();
-                    } else {
-                        // unhide
-                        $command = new EnableNodeAggregate(
-                            $node->getContentStreamIdentifier(),
-                            $node->getNodeAggregateIdentifier(),
-                            $node->getOriginDimensionSpacePoint(),
-                            NodeVariantSelectionStrategyIdentifier::allSpecializations()
-                        );
-                        $this->nodeAggregateCommandHandler->handleEnableNodeAggregate($command)->blockUntilProjectionsAreUpToDate();
-                    }
+                $value = $this->nodePropertyConversionService->convert(
+                    $node->getNodeType(),
+                    $propertyName,
+                    $this->getValue()
+                );
+
+                // TODO: Make changing the node type a separated, specific/defined change operation.
+                if ($propertyName{0} !== '_' || $propertyName === '_hiddenInIndex') {
+                    $propertyType = $this->nodeTypeManager->getNodeType((string)$node->getNodeType())->getPropertyType($propertyName);
+                    $command = new SetNodeProperties(
+                        $node->getContentStreamIdentifier(),
+                        $node->getNodeAggregateIdentifier(),
+                        $node->getOriginDimensionSpacePoint(),
+                        PropertyValues::fromArray(
+                            [
+                                $propertyName => new PropertyValue($value, $propertyType)
+                            ]
+                        )
+                    );
+                    $this->nodeAggregateCommandHandler->handleSetNodeProperties($command)->blockUntilProjectionsAreUpToDate();
                 } else {
-                    throw new \Exception("TODO FIX");
+                    // property starts with "_"
+                    if ($propertyName === '_nodeType') {
+                        throw new \Exception("TODO FIX");
+                        $nodeType = $this->nodeTypeManager->getNodeType($value);
+                        $node = $this->changeNodeType($node, $nodeType);
+                    } elseif ($propertyName === '_hidden') {
+                        if ($value === true) {
+                            $command = new DisableNodeAggregate(
+                                $node->getContentStreamIdentifier(),
+                                $node->getNodeAggregateIdentifier(),
+                                $node->getOriginDimensionSpacePoint(),
+                                NodeVariantSelectionStrategyIdentifier::allSpecializations()
+                            );
+                            $this->nodeAggregateCommandHandler->handleDisableNodeAggregate($command)->blockUntilProjectionsAreUpToDate();
+                        } else {
+                            // unhide
+                            $command = new EnableNodeAggregate(
+                                $node->getContentStreamIdentifier(),
+                                $node->getNodeAggregateIdentifier(),
+                                $node->getOriginDimensionSpacePoint(),
+                                NodeVariantSelectionStrategyIdentifier::allSpecializations()
+                            );
+                            $this->nodeAggregateCommandHandler->handleEnableNodeAggregate($command)->blockUntilProjectionsAreUpToDate();
+                        }
+                    } else {
+                        throw new \Exception("TODO FIX");
+                    }
                 }
             }
 

--- a/Neos.EventSourcedNeosAdjustments/Classes/Ui/Domain/Model/Changes/Property.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/Ui/Domain/Model/Changes/Property.php
@@ -208,8 +208,9 @@ class Property extends AbstractChange
             $propertyName = $this->getPropertyName();
 
             $propertyType = $node->getNodeType()->getPropertyType($propertyName);
-            if ($propertyType === 'reference' || $propertyType === 'references') {
 
+            // Use extra commands for reference handling
+            if ($propertyType === 'reference' || $propertyType === 'references') {
                 $value = $this->getValue();
                 $destinationNodeAggregateIdentifiers = [];
                 if ($propertyType === 'reference') {


### PR DESCRIPTION
FEATURE: implement full-text search for backend reference editors; fix reference editors in backend

- send Node References to UI properly
  (NodePropertyConverterService::class)
- emit correct SetNodeReferences command when a node
  reference changes (Property::class)
- Fix Node Search in backend:
  - extend ContentSubgraph::findDescendants to allow a
    fulltext SearchTerm
  - add custom ServiceNodesController, replacing the
    corresponding controller from Neos.
  - override ClosestDocumentViewHelper, as it is used
    in the ServiceNodesController view