### PR TITLE
BUGFIX: Fix NodeAddress method name

### DIFF
--- a/Neos.EventSourcedContentRepository/Classes/Domain/Context/NodeAddress/NodeAddress.php
+++ b/Neos.EventSourcedContentRepository/Classes/Domain/Context/NodeAddress/NodeAddress.php
@@ -94,7 +94,7 @@ final class NodeAddress
      * @param NodeAggregateIdentifier $nodeAggregateIdentifier
      * @return NodeAddress
      */
-    public function setNodeAggregateIdentifier(NodeAggregateIdentifier $nodeAggregateIdentifier): NodeAddress
+    public function withNodeAggregateIdentifier(NodeAggregateIdentifier $nodeAggregateIdentifier): NodeAddress
     {
         return new NodeAddress($this->contentStreamIdentifier, $this->dimensionSpacePoint, $nodeAggregateIdentifier, $this->workspaceName);
     }

--- a/Neos.EventSourcedNeosAdjustments/Classes/Domain/Service/NodeShortcutResolver.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/Domain/Service/NodeShortcutResolver.php
@@ -90,7 +90,7 @@ class NodeShortcutResolver
             throw new NodeNotFoundException('The requested node does not exist or isn\'t accessible to the current user', 1502793585);
         }
 
-        $newNodeAddress = $nodeAddress->setNodeAggregateIdentifier($resolvedNode->getNodeAggregateIdentifier());
+        $newNodeAddress = $nodeAddress->withNodeAggregateIdentifier($resolvedNode->getNodeAggregateIdentifier());
         $uriBuilder->reset();
         $uriBuilder->setFormat($format);
 


### PR DESCRIPTION
`setNodeAggregateIdentifier()` was misleading because it doesn't
mutate the instance.
Renamed the method to `withNodeAggregateIdentifier()` and adjusted
the single usage correspondingly.