### PR TITLE
Simplify creation of multiple nodes in Behat features

### DIFF
--- a/Neos.EventSourcedContentRepository/Tests/Behavior/Features/Bootstrap/EventSourcedTrait.php
+++ b/Neos.EventSourcedContentRepository/Tests/Behavior/Features/Bootstrap/EventSourcedTrait.php
@@ -619,6 +619,39 @@ trait EventSourcedTrait
     }
 
     /**
+     * @When the following CreateNodeAggregateWithNode commands are executed for content stream :contentStreamIdentifier and origin :originSpacePoint:
+     * @throws JsonException
+     */
+    public function theFollowingCreateNodeAggregateWithNodeCommandsAreExecuted(string $contentStreamIdentifier, string $originSpacePoint, TableNode $table): void
+    {
+        foreach ($table->getHash() as $row) {
+            $command = new CreateNodeAggregateWithNode(
+                ContentStreamIdentifier::fromString($contentStreamIdentifier),
+                NodeAggregateIdentifier::fromString($row['nodeAggregateIdentifier']),
+                NodeTypeName::fromString($row['nodeTypeName']),
+                OriginDimensionSpacePoint::fromJsonString($originSpacePoint),
+                UserIdentifier::forSystemUser(),
+                NodeAggregateIdentifier::fromString($row['parentNodeAggregateIdentifier']),
+                !empty($row['succeedingSiblingNodeAggregateIdentifier'])
+                    ? NodeAggregateIdentifier::fromString($row['succeedingSiblingNodeAggregateIdentifier'])
+                    : null,
+                !empty($row['nodeName'])
+                    ? NodeName::fromString($row['nodeName'])
+                    : null,
+                !empty($row['initialPropertyValues'])
+                    ? PropertyValuesToWrite::fromArray(json_decode($row['initialPropertyValues'], true, 512, JSON_THROW_ON_ERROR))
+                    : null,
+                !empty($row['tetheredDescendantNodeAggregateIdentifiers'])
+                    ? NodeAggregateIdentifiersByNodePaths::fromArray(json_decode($row['tetheredDescendantNodeAggregateIdentifiers'], true, 512, JSON_THROW_ON_ERROR))
+                    : null
+            );
+            $this->lastCommandOrEventResult = $this->getNodeAggregateCommandHandler()
+                ->handleCreateNodeAggregateWithNode($command);
+            $this->theGraphProjectionIsFullyUpToDate();
+        }
+    }
+
+    /**
      * @When /^the command CreateNodeAggregateWithNode is executed with payload and exceptions are caught:$/
      * @param TableNode $payloadTable
      */

--- a/Neos.EventSourcedContentRepository/Tests/Behavior/Features/EventSourced/NodeReferencing/NodeReferencesWithoutDimensions.feature
+++ b/Neos.EventSourcedContentRepository/Tests/Behavior/Features/EventSourced/NodeReferencing/NodeReferencesWithoutDimensions.feature
@@ -16,7 +16,7 @@ Feature: Node References without Dimensions
           type: references
     """
     And the command CreateRootWorkspace is executed with payload:
-      | Key                      | Value                                  |
+      | Key                        | Value                                  |
       | workspaceName              | "live"                                 |
       | workspaceTitle             | "Live"                                 |
       | workspaceDescription       | "The live workspace"                   |
@@ -30,38 +30,12 @@ Feature: Node References without Dimensions
       | nodeTypeName             | "Neos.ContentRepository:Root"          |
       | initiatingUserIdentifier | "00000000-0000-0000-0000-000000000000" |
     And the graph projection is fully up to date
-    And the command CreateNodeAggregateWithNode is executed with payload:
-      | Key                           | Value                                               |
-      | contentStreamIdentifier       | "cs-identifier"                                     |
-      | nodeAggregateIdentifier       | "source-nodandaise"                                 |
-      | nodeTypeName                  | "Neos.ContentRepository.Testing:NodeWithReferences" |
-      | initiatingUserIdentifier      | "00000000-0000-0000-0000-000000000000"              |
-      | parentNodeAggregateIdentifier | "lady-eleonode-rootford"                            |
-    And the graph projection is fully up to date
-    And the command CreateNodeAggregateWithNode is executed with payload:
-      | Key                           | Value                                               |
-      | contentStreamIdentifier       | "cs-identifier"                                     |
-      | nodeAggregateIdentifier       | "anthony-destinode"                                 |
-      | nodeTypeName                  | "Neos.ContentRepository.Testing:NodeWithReferences" |
-      | initiatingUserIdentifier      | "00000000-0000-0000-0000-000000000000"              |
-      | parentNodeAggregateIdentifier | "lady-eleonode-rootford"                            |
-    And the graph projection is fully up to date
-    And the command CreateNodeAggregateWithNode is executed with payload:
-      | Key                           | Value                                               |
-      | contentStreamIdentifier       | "cs-identifier"                                     |
-      | nodeAggregateIdentifier       | "berta-destinode"                                   |
-      | nodeTypeName                  | "Neos.ContentRepository.Testing:NodeWithReferences" |
-      | initiatingUserIdentifier      | "00000000-0000-0000-0000-000000000000"              |
-      | parentNodeAggregateIdentifier | "lady-eleonode-rootford"                            |
-    And the graph projection is fully up to date
-    And the command CreateNodeAggregateWithNode is executed with payload:
-      | Key                           | Value                                               |
-      | contentStreamIdentifier       | "cs-identifier"                                     |
-      | nodeAggregateIdentifier       | "carl-destinode"                                    |
-      | nodeTypeName                  | "Neos.ContentRepository.Testing:NodeWithReferences" |
-      | initiatingUserIdentifier      | "00000000-0000-0000-0000-000000000000"              |
-      | parentNodeAggregateIdentifier | "lady-eleonode-rootford"                            |
-    And the graph projection is fully up to date
+    And the following CreateNodeAggregateWithNode commands are executed for content stream "cs-identifier" and origin "{}":
+      | nodeAggregateIdentifier | parentNodeAggregateIdentifier | nodeTypeName                                      |
+      | source-nodandaise       | lady-eleonode-rootford        | Neos.ContentRepository.Testing:NodeWithReferences |
+      | anthony-destinode       | lady-eleonode-rootford        | Neos.ContentRepository.Testing:NodeWithReferences |
+      | berta-destinode         | lady-eleonode-rootford        | Neos.ContentRepository.Testing:NodeWithReferences |
+      | carl-destinode          | lady-eleonode-rootford        | Neos.ContentRepository.Testing:NodeWithReferences |
 
   Scenario: Ensure that a reference between nodes can be set and read
     When the command SetNodeReferences is executed with payload:

--- a/Neos.EventSourcedNeosAdjustments/Tests/Behavior/Features/FlowQuery/FindOperation.feature
+++ b/Neos.EventSourcedNeosAdjustments/Tests/Behavior/Features/FlowQuery/FindOperation.feature
@@ -16,12 +16,12 @@ Feature: The FlowQuery find operation
     'Neos.ContentRepository.Testing:Document': []
     """
     And the event RootWorkspaceWasCreated was published with payload:
-      | Key                            | Value                                  |
-      | workspaceName                  | "live"                                 |
-      | workspaceTitle                 | "Live"                                 |
-      | workspaceDescription           | "The live workspace"                   |
-      | initiatingUserIdentifier       | "00000000-0000-0000-0000-000000000000" |
-      | newContentStreamIdentifier     | "cs-identifier"                        |
+      | Key                        | Value                                  |
+      | workspaceName              | "live"                                 |
+      | workspaceTitle             | "Live"                                 |
+      | workspaceDescription       | "The live workspace"                   |
+      | initiatingUserIdentifier   | "00000000-0000-0000-0000-000000000000" |
+      | newContentStreamIdentifier | "cs-identifier"                        |
     And the event RootNodeAggregateWithNodeWasCreated was published with payload:
       | Key                         | Value                                  |
       | contentStreamIdentifier     | "cs-identifier"                        |
@@ -50,26 +50,10 @@ Feature: The FlowQuery find operation
     Then I expect a node identified by aggregate identifier "nodewyn-tetherton" to exist in the FlowQuery context
 
   Scenario: Find named descendant, e.g. via q(node).find('parent/child')
-    When the command CreateNodeAggregateWithNode is executed with payload:
-      | Key                           | Value                                     |
-      | contentStreamIdentifier       | "cs-identifier"                           |
-      | nodeAggregateIdentifier       | "sir-david-nodenborough"                  |
-      | nodeTypeName                  | "Neos.ContentRepository.Testing:Document" |
-      | nodeName                      | "parent"                                  |
-      | originDimensionSpacePoint     | {}                                        |
-      | initiatingUserIdentifier      | "00000000-0000-0000-0000-000000000000"    |
-      | parentNodeAggregateIdentifier | "lady-eleonode-rootford"                  |
-    And the graph projection is fully up to date
-    And the command CreateNodeAggregateWithNode is executed with payload:
-      | Key                           | Value                                     |
-      | contentStreamIdentifier       | "cs-identifier"                           |
-      | nodeAggregateIdentifier       | "nody-mc-nodeface"                        |
-      | nodeTypeName                  | "Neos.ContentRepository.Testing:Document" |
-      | nodeName                      | "child"                                   |
-      | originDimensionSpacePoint     | {}                                        |
-      | initiatingUserIdentifier      | "00000000-0000-0000-0000-000000000000"    |
-      | parentNodeAggregateIdentifier | "sir-david-nodenborough"                  |
-    And the graph projection is fully up to date
+    When the following CreateNodeAggregateWithNode commands are executed for content stream "cs-identifier" and origin "{}":
+      | nodeAggregateIdentifier | parentNodeAggregateIdentifier | nodeTypeName                            | nodeName |
+      | sir-david-nodenborough  | lady-eleonode-rootford        | Neos.ContentRepository.Testing:Document | parent   |
+      | nody-mc-nodeface        | sir-david-nodenborough        | Neos.ContentRepository.Testing:Document | child    |
 
     When I am in content stream "cs-identifier" and Dimension Space Point {}
     And I have a FlowQuery with node "lady-eleonode-rootford"
@@ -77,26 +61,10 @@ Feature: The FlowQuery find operation
     Then I expect a node identified by aggregate identifier "nody-mc-nodeface" to exist in the FlowQuery context
 
   Scenario: Find named node by absolute path, e.g. via q(node).find('/parent/child')
-    When the command CreateNodeAggregateWithNode is executed with payload:
-      | Key                           | Value                                     |
-      | contentStreamIdentifier       | "cs-identifier"                           |
-      | nodeAggregateIdentifier       | "sir-david-nodenborough"                  |
-      | nodeTypeName                  | "Neos.ContentRepository.Testing:Document" |
-      | nodeName                      | "parent"                                  |
-      | originDimensionSpacePoint     | {}                                        |
-      | initiatingUserIdentifier      | "00000000-0000-0000-0000-000000000000"    |
-      | parentNodeAggregateIdentifier | "lady-eleonode-rootford"                  |
-    And the graph projection is fully up to date
-    And the command CreateNodeAggregateWithNode is executed with payload:
-      | Key                           | Value                                     |
-      | contentStreamIdentifier       | "cs-identifier"                           |
-      | nodeAggregateIdentifier       | "nody-mc-nodeface"                        |
-      | nodeTypeName                  | "Neos.ContentRepository.Testing:Document" |
-      | nodeName                      | "child"                                   |
-      | originDimensionSpacePoint     | {}                                        |
-      | initiatingUserIdentifier      | "00000000-0000-0000-0000-000000000000"    |
-      | parentNodeAggregateIdentifier | "sir-david-nodenborough"                  |
-    And the graph projection is fully up to date
+    When the following CreateNodeAggregateWithNode commands are executed for content stream "cs-identifier" and origin "{}":
+      | nodeAggregateIdentifier | parentNodeAggregateIdentifier | nodeTypeName                            | nodeName |
+      | sir-david-nodenborough  | lady-eleonode-rootford        | Neos.ContentRepository.Testing:Document | parent   |
+      | nody-mc-nodeface        | sir-david-nodenborough        | Neos.ContentRepository.Testing:Document | child    |
 
     When I am in content stream "cs-identifier" and Dimension Space Point {}
     And I have a FlowQuery with node "sir-david-nodenborough"
@@ -104,85 +72,35 @@ Feature: The FlowQuery find operation
     Then I expect a node identified by aggregate identifier "nody-mc-nodeface" to exist in the FlowQuery context
 
   Scenario: Find node by identifier, e.g. via q(node).find('#nody-mc-nodeface')
-    When the command CreateNodeAggregateWithNode is executed with payload:
-      | Key                           | Value                                     |
-      | contentStreamIdentifier       | "cs-identifier"                           |
-      | nodeAggregateIdentifier       | "sir-david-nodenborough"                  |
-      | nodeTypeName                  | "Neos.ContentRepository.Testing:Document" |
-      | nodeName                      | "parent"                                  |
-      | originDimensionSpacePoint     | {}                                        |
-      | initiatingUserIdentifier      | "00000000-0000-0000-0000-000000000000"    |
-      | parentNodeAggregateIdentifier | "lady-eleonode-rootford"                  |
-    And the graph projection is fully up to date
-    And the command CreateNodeAggregateWithNode is executed with payload:
-      | Key                           | Value                                     |
-      | contentStreamIdentifier       | "cs-identifier"                           |
-      | nodeAggregateIdentifier       | "nody-mc-nodeface"                        |
-      | nodeTypeName                  | "Neos.ContentRepository.Testing:Document" |
-      | nodeName                      | "child"                                   |
-      | originDimensionSpacePoint     | {}                                        |
-      | initiatingUserIdentifier      | "00000000-0000-0000-0000-000000000000"    |
-      | parentNodeAggregateIdentifier | "sir-david-nodenborough"                  |
-    And the graph projection is fully up to date
+    When the following CreateNodeAggregateWithNode commands are executed for content stream "cs-identifier" and origin "{}":
+      | nodeAggregateIdentifier | parentNodeAggregateIdentifier | nodeTypeName                            | nodeName |
+      | sir-david-nodenborough  | lady-eleonode-rootford        | Neos.ContentRepository.Testing:Document | parent   |
+      | nody-mc-nodeface        | sir-david-nodenborough        | Neos.ContentRepository.Testing:Document | child    |
 
     When I am in content stream "cs-identifier" and Dimension Space Point {}
     And I have a FlowQuery with node "lady-eleonode-rootford"
     And I call FlowQuery operation "find" with argument "#nody-mc-nodeface"
     Then I expect a node identified by aggregate identifier "nody-mc-nodeface" to exist in the FlowQuery context
 
-    Scenario: Find nodes by node type, e.g. via q(node).find('[instanceof Neos.ContentRepository.Testing:Document]')
-      When the command CreateNodeAggregateWithNode is executed with payload:
-        | Key                           | Value                                     |
-        | contentStreamIdentifier       | "cs-identifier"                           |
-        | nodeAggregateIdentifier       | "sir-david-nodenborough"                  |
-        | nodeTypeName                  | "Neos.ContentRepository.Testing:Document" |
-        | originDimensionSpacePoint     | {}                                        |
-        | initiatingUserIdentifier      | "00000000-0000-0000-0000-000000000000"    |
-        | parentNodeAggregateIdentifier | "lady-eleonode-rootford"                  |
-      And the command CreateNodeAggregateWithNode is executed with payload:
-        | Key                           | Value                                     |
-        | contentStreamIdentifier       | "cs-identifier"                           |
-        | nodeAggregateIdentifier       | "sir-nodeward-nodington-iii"              |
-        | nodeTypeName                  | "Neos.ContentRepository.Testing:Document" |
-        | originDimensionSpacePoint     | {}                                        |
-        | initiatingUserIdentifier      | "00000000-0000-0000-0000-000000000000"    |
-        | parentNodeAggregateIdentifier | "lady-eleonode-rootford"                  |
-      And the graph projection is fully up to date
-      And the command CreateNodeAggregateWithNode is executed with payload:
-        | Key                           | Value                                     |
-        | contentStreamIdentifier       | "cs-identifier"                           |
-        | nodeAggregateIdentifier       | "albert-nodesworth"                       |
-        | nodeTypeName                  | "Neos.ContentRepository.Testing:Document" |
-        | originDimensionSpacePoint     | {}                                        |
-        | initiatingUserIdentifier      | "00000000-0000-0000-0000-000000000000"    |
-        | parentNodeAggregateIdentifier | "sir-david-nodenborough"                  |
-      And the command CreateNodeAggregateWithNode is executed with payload:
-        | Key                           | Value                                     |
-        | contentStreamIdentifier       | "cs-identifier"                           |
-        | nodeAggregateIdentifier       | "berta-nodesworth"                       |
-        | nodeTypeName                  | "Neos.ContentRepository.Testing:Document" |
-        | originDimensionSpacePoint     | {}                                        |
-        | initiatingUserIdentifier      | "00000000-0000-0000-0000-000000000000"    |
-        | parentNodeAggregateIdentifier | "sir-nodeward-nodington-iii"                  |
-      And the command CreateNodeAggregateWithNode is executed with payload:
-        | Key                           | Value                                     |
-        | contentStreamIdentifier       | "cs-identifier"                           |
-        | nodeAggregateIdentifier       | "carl-nodesworth"                       |
-        | nodeTypeName                  | "Neos.ContentRepository.Testing:NodeWithTetheredChildNodes" |
-        | originDimensionSpacePoint     | {}                                        |
-        | initiatingUserIdentifier      | "00000000-0000-0000-0000-000000000000"    |
-        | parentNodeAggregateIdentifier | "sir-david-nodenborough"                  |
-      And the graph projection is fully up to date
+  Scenario: Find nodes by node type, e.g. via q(node).find('[instanceof Neos.ContentRepository.Testing:Document]')
 
-      When I am in content stream "cs-identifier" and Dimension Space Point {}
+    When the following CreateNodeAggregateWithNode commands are executed for content stream "cs-identifier" and origin "{}":
+      | nodeAggregateIdentifier    | parentNodeAggregateIdentifier | nodeTypeName                                              |
+      | sir-david-nodenborough     | lady-eleonode-rootford        | Neos.ContentRepository.Testing:Document                   |
+      | sir-nodeward-nodington-iii | lady-eleonode-rootford        | Neos.ContentRepository.Testing:Document                   |
+      | albert-nodesworth          | sir-david-nodenborough        | Neos.ContentRepository.Testing:Document                   |
+      | berta-nodesworth           | sir-nodeward-nodington-iii    | Neos.ContentRepository.Testing:Document                   |
+      | carl-nodesworth            | sir-david-nodenborough        | Neos.ContentRepository.Testing:NodeWithTetheredChildNodes |
 
-      And I have a FlowQuery with node "sir-david-nodenborough"
-      And I call FlowQuery operation "find" with argument "[instanceof Neos.ContentRepository.Testing:Document]"
-      Then I expect the FlowQuery context to consist of exactly 1 item
-      And I expect a node identified by aggregate identifier "albert-nodesworth" to exist in the FlowQuery context
+    When I am in content stream "cs-identifier" and Dimension Space Point {}
 
-      And I have a FlowQuery with node "sir-david-nodenborough"
-      And I call FlowQuery operation "find" with argument "[instanceof Neos.ContentRepository.Testing:Document],[instanceof Neos.ContentRepository.Testing:NodeWithTetheredChildNodes]"
-      Then I expect the FlowQuery context to consist of exactly 2 items
-      And I expect a node identified by aggregate identifier "albert-nodesworth" to exist in the FlowQuery context
-      And I expect a node identified by aggregate identifier "carl-nodesworth" to exist in the FlowQuery context
+    And I have a FlowQuery with node "sir-david-nodenborough"
+    And I call FlowQuery operation "find" with argument "[instanceof Neos.ContentRepository.Testing:Document]"
+    Then I expect the FlowQuery context to consist of exactly 1 item
+    And I expect a node identified by aggregate identifier "albert-nodesworth" to exist in the FlowQuery context
+
+    And I have a FlowQuery with node "sir-david-nodenborough"
+    And I call FlowQuery operation "find" with argument "[instanceof Neos.ContentRepository.Testing:Document],[instanceof Neos.ContentRepository.Testing:NodeWithTetheredChildNodes]"
+    Then I expect the FlowQuery context to consist of exactly 2 items
+    And I expect a node identified by aggregate identifier "albert-nodesworth" to exist in the FlowQuery context
+    And I expect a node identified by aggregate identifier "carl-nodesworth" to exist in the FlowQuery context


### PR DESCRIPTION
Adds a step definition to the `EventSourcedTrait` that makes it easier
to read and write multiple `CreateNodeAggregateWithNode` for the same
content stream and origin dimension space point.

Usage:

    Given the following CreateNodeAggregateWithNode commands are executed for content stream "cs-identifier" and origin '{"language":"de"}':
     | nodeAggregateIdentifier | parentNodeAggregateIdentifier | nodeTypeName           |
     | some-node-id            | some-parent-node-id           | Some.Node:Type         |
     | some-other-node-id      | some-parent-node-id           | Some.Other.Node:Type   |