### PR TITLE
BUGFIX: ContentTitleNodeCreationHandler needs adjustments

### DIFF
--- a/Neos.EventSourcedNeosAdjustments/Classes/Ui/Domain/Model/Changes/AbstractCreate.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/Ui/Domain/Model/Changes/AbstractCreate.php
@@ -192,7 +192,7 @@ abstract class AbstractCreate extends AbstractStructuralChange
         foreach ($nodeType->getOptions()['nodeCreationHandlers'] as $nodeCreationHandlerConfiguration) {
             $nodeCreationHandler = new $nodeCreationHandlerConfiguration['nodeCreationHandler']();
             if (!$nodeCreationHandler instanceof NodeCreationHandlerInterface) {
-                throw new InvalidNodeCreationHandlerException(sprintf('Expected NodeCreationHandlerInterface but got "%s"', get_class($nodeCreationHandler)), 1364759956);
+                throw new InvalidNodeCreationHandlerException(sprintf('Expected %s but got "%s"', NodeCreationHandlerInterface::class, get_class($nodeCreationHandler)), 1364759956);
             }
             $command = $nodeCreationHandler->handle($command, $data);
         }

--- a/Neos.EventSourcedNeosAdjustments/Classes/Ui/NodeCreationHandler/ContentTitleNodeCreationHandler.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/Ui/NodeCreationHandler/ContentTitleNodeCreationHandler.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+namespace Neos\EventSourcedNeosAdjustments\Ui\NodeCreationHandler;
+
+/*
+ * This file is part of the Neos.Neos.Ui package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\ContentRepository\Domain\Service\NodeTypeManager;
+use Neos\ContentRepository\Exception\NodeTypeNotFoundException;
+use Neos\EventSourcedContentRepository\Domain\Context\NodeAggregate\Command\CreateNodeAggregateWithNode;
+use Neos\Flow\Annotations as Flow;
+use Neos\Neos\Service\TransliterationService;
+
+/**
+ * Node creation handler that sets the "title" property for new content elements according
+ * to the incoming title from a creation dialog.
+ *
+ * Note: This is not actually a Command Handler in the sense of CQRS but rather some kind of
+ *       "command enricher"
+ */
+class ContentTitleNodeCreationHandler implements NodeCreationHandlerInterface
+{
+    /**
+     * @Flow\Inject
+     * @var NodeTypeManager
+     */
+    protected $nodeTypeManager;
+
+    /**
+     * @Flow\Inject
+     * @var TransliterationService
+     */
+    protected $transliterationService;
+
+    /**
+     * Set the node title for the newly created Content node
+     *
+     * @param CreateNodeAggregateWithNode $command
+     * @param array $data incoming data from the creationDialog
+     * @return CreateNodeAggregateWithNode
+     * @throws NodeTypeNotFoundException
+     */
+    public function handle(CreateNodeAggregateWithNode $command, array $data): CreateNodeAggregateWithNode
+    {
+        if (!$this->nodeTypeManager->getNodeType($command->getNodeTypeName()->getValue())->isOfType('Neos.Neos:Content')) {
+            return $command;
+        }
+
+        $propertyValues = $command->getInitialPropertyValues();
+        if (isset($data['title'])) {
+            $propertyValues = $propertyValues->withValue('title', $data['title']);
+        }
+
+        return $command->withInitialPropertyValues($propertyValues);
+    }
+}

--- a/Neos.EventSourcedNeosAdjustments/Classes/Ui/NodeCreationHandler/DocumentTitleNodeCreationHandler.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/Ui/NodeCreationHandler/DocumentTitleNodeCreationHandler.php
@@ -24,8 +24,12 @@ use Neos\Neos\Service\TransliterationService;
 
 /**
  * Node creation handler that
- * * sets the "title" property according to the incoming title from a creation dialog
- * * sets the "uriPathSegment" property according to the specified title or node name
+ *
+ * - sets the "title" property according to the incoming title from a creation dialog
+ * - sets the "uriPathSegment" property according to the specified title or node name
+ *
+ * Note: This is not actually a Command Handler in the sense of CQRS but rather some kind of
+ *       "command enricher"
  */
 class DocumentTitleNodeCreationHandler implements NodeCreationHandlerInterface
 {

--- a/Neos.EventSourcedNeosAdjustments/Configuration/NodeTypes.yaml
+++ b/Neos.EventSourcedNeosAdjustments/Configuration/NodeTypes.yaml
@@ -25,5 +25,8 @@
 'Neos.Neos:Content':
   options:
     nodeCreationHandlers:
+      # ⚠️ This should actually be "contentTitle", but it's "documentTitle" in Neos.Neos.Ui (see https://github.com/neos/neos-ui/pull/2563/files)
+      documentTitle:
+        nodeCreationHandler: 'Neos\EventSourcedNeosAdjustments\Ui\NodeCreationHandler\ContentTitleNodeCreationHandler'
       creationDialogProperties:
         nodeCreationHandler: 'Neos\EventSourcedNeosAdjustments\Ui\NodeCreationHandler\CreationDialogPropertiesCreationHandler'


### PR DESCRIPTION
This change introduces the `ContentTitleNodeCreationHandler` to the EventSourcedNeosAdjustments package. Without these adjustments, creation of new content elements via the UI was not possible.

Resolves #151