### PR TITLE
BUGFIX: NodeAggregateWasRemoved listener is broken in ChangeProjector

### DIFF
--- a/Neos.EventSourcedContentRepository/Classes/Domain/Projection/Changes/ChangeProjector.php
+++ b/Neos.EventSourcedContentRepository/Classes/Domain/Projection/Changes/ChangeProjector.php
@@ -113,10 +113,10 @@ class ChangeProjector implements ProjectorInterface
                 [
                     'contentStreamIdentifier' => (string)$event->getContentStreamIdentifier(),
                     'nodeAggregateIdentifier' => (string)$event->getNodeAggregateIdentifier(),
-                    'affectedDimensionSpacePointHashes' => $event->getAffectedOccupiedDimensionSpacePoints()
+                    'affectedDimensionSpacePointHashes' => $event->getAffectedOccupiedDimensionSpacePoints()->getPointHashes()
                 ],
                 [
-                    'dimensionSpacePointHashes' => Connection::PARAM_STR_ARRAY
+                    'affectedDimensionSpacePointHashes' => Connection::PARAM_STR_ARRAY
                 ]
             );
 


### PR DESCRIPTION
This fixes an issue in the `ChangeProjector` which resulted in
duplicate key errors while handling NodeAggregateWasRemoved events.