### PR TITLE
BUGFIX: Allow moving of unnamed nodes

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/Classes/Domain/Projection/GraphProjector.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Classes/Domain/Projection/GraphProjector.php
@@ -209,7 +209,7 @@ class GraphProjector extends AbstractProcessedEventsAwareProjector
      * @param SerializedPropertyValues $propertyDefaultValuesAndTypes
      * @param NodeAggregateClassification $nodeAggregateClassification
      * @param NodeAggregateIdentifier|null $succeedingSiblingNodeAggregateIdentifier
-     * @param NodeName $nodeName
+     * @param NodeName|null $nodeName
      * @throws \Doctrine\DBAL\DBALException
      */
     private function createNodeWithHierarchy(

--- a/Neos.ContentGraph.DoctrineDbalAdapter/Classes/Domain/Projection/HierarchyRelation.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Classes/Domain/Projection/HierarchyRelation.php
@@ -61,7 +61,7 @@ class HierarchyRelation
     /**
      * @param NodeRelationAnchorPoint $parentNodeAnchor
      * @param NodeRelationAnchorPoint $childNodeAnchor
-     * @param NodeName $name
+     * @param NodeName|null $name
      * @param ContentStreamIdentifier $contentStreamIdentifier
      * @param DimensionSpacePoint $dimensionSpacePoint
      * @param string $dimensionSpacePointHash

--- a/Neos.EventSourcedContentRepository/Classes/Domain/Context/NodeAggregate/Event/NodeAggregateWithNodeWasCreated.php
+++ b/Neos.EventSourcedContentRepository/Classes/Domain/Context/NodeAggregate/Event/NodeAggregateWithNodeWasCreated.php
@@ -107,7 +107,7 @@ final class NodeAggregateWithNodeWasCreated implements DomainEventInterface, Pub
      * @param OriginDimensionSpacePoint $originDimensionSpacePoint
      * @param DimensionSpacePointSet $coveredDimensionSpacePoints
      * @param NodeAggregateIdentifier $parentNodeAggregateIdentifier
-     * @param NodeName $nodeName
+     * @param NodeName|null $nodeName
      * @param SerializedPropertyValues $initialPropertyValues
      * @param NodeAggregateClassification $nodeAggregateClassification
      * @param NodeAggregateIdentifier|null $succeedingNodeAggregateIdentifier

--- a/Neos.EventSourcedContentRepository/Classes/Domain/Context/NodeAggregate/Feature/ConstraintChecks.php
+++ b/Neos.EventSourcedContentRepository/Classes/Domain/Context/NodeAggregate/Feature/ConstraintChecks.php
@@ -209,7 +209,7 @@ trait ConstraintChecks
         return true;
     }
 
-    protected function requireNodeTypeConstraintsImposedByGrandparentToBeMet(NodeType $grandParentsNodeType, NodeName $parentNodeName, NodeType $nodeType): void
+    protected function requireNodeTypeConstraintsImposedByGrandparentToBeMet(NodeType $grandParentsNodeType, ?NodeName $parentNodeName, NodeType $nodeType): void
     {
         if (!$this->areNodeTypeConstraintsImposedByGrandparentValid($grandParentsNodeType, $parentNodeName, $nodeType)) {
             throw new NodeConstraintException('Node type "' . $nodeType . '" is not allowed below tethered child nodes "' . $parentNodeName
@@ -217,7 +217,7 @@ trait ConstraintChecks
         }
     }
 
-    protected function areNodeTypeConstraintsImposedByGrandparentValid(NodeType $grandParentsNodeType, NodeName $parentNodeName, NodeType $nodeType): bool
+    protected function areNodeTypeConstraintsImposedByGrandparentValid(NodeType $grandParentsNodeType, ?NodeName $parentNodeName, NodeType $nodeType): bool
     {
         if ($parentNodeName
             && $grandParentsNodeType->hasAutoCreatedChildNode($parentNodeName)
@@ -344,7 +344,7 @@ trait ConstraintChecks
 
     /**
      * @param ContentStreamIdentifier $contentStreamIdentifier
-     * @param NodeName $nodeName
+     * @param NodeName|null $nodeName
      * @param NodeAggregateIdentifier $parentNodeAggregateIdentifier
      * @param OriginDimensionSpacePoint $parentOriginDimensionSpacePoint
      * @param DimensionSpacePointSet $dimensionSpacePoints
@@ -352,12 +352,15 @@ trait ConstraintChecks
      */
     protected function requireNodeNameToBeUnoccupied(
         ContentStreamIdentifier $contentStreamIdentifier,
-        NodeName $nodeName,
+        ?NodeName $nodeName,
         NodeAggregateIdentifier $parentNodeAggregateIdentifier,
         OriginDimensionSpacePoint $parentOriginDimensionSpacePoint,
         DimensionSpacePointSet $dimensionSpacePoints
     ): void
     {
+        if ($nodeName === null) {
+            return;
+        }
         $dimensionSpacePointsOccupiedByChildNodeName = $this->getContentGraph()->getDimensionSpacePointsOccupiedByChildNodeName(
             $contentStreamIdentifier,
             $nodeName,
@@ -372,18 +375,21 @@ trait ConstraintChecks
 
     /**
      * @param ContentStreamIdentifier $contentStreamIdentifier
-     * @param NodeName $nodeName
+     * @param NodeName|null $nodeName
      * @param NodeAggregateIdentifier $parentNodeAggregateIdentifier
      * @param DimensionSpacePointSet $dimensionSpacePointsToBeCovered
      * @throws NodeNameIsAlreadyCovered
      */
     protected function requireNodeNameToBeUncovered(
         ContentStreamIdentifier $contentStreamIdentifier,
-        NodeName $nodeName,
+        ?NodeName $nodeName,
         NodeAggregateIdentifier $parentNodeAggregateIdentifier,
         DimensionSpacePointSet $dimensionSpacePointsToBeCovered
     ): void
     {
+        if ($nodeName === null) {
+            return;
+        }
         $childNodeAggregates = $this->getContentGraph()->findChildNodeAggregatesByName($contentStreamIdentifier, $parentNodeAggregateIdentifier, $nodeName);
         foreach ($childNodeAggregates as $childNodeAggregate) {
             $alreadyCoveredDimensionSpacePoints = $childNodeAggregate->getCoveredDimensionSpacePoints()->getIntersection($dimensionSpacePointsToBeCovered);

--- a/Neos.EventSourcedContentRepository/Classes/Domain/Context/NodeAggregate/Feature/NodeMove.php
+++ b/Neos.EventSourcedContentRepository/Classes/Domain/Context/NodeAggregate/Feature/NodeMove.php
@@ -96,14 +96,12 @@ trait NodeMove
                     [$command->getNewParentNodeAggregateIdentifier()]
                 );
 
-                if ($nodeAggregate->getNodeName() !== null) {
-                    $this->requireNodeNameToBeUncovered(
-                        $command->getContentStreamIdentifier(),
-                        $nodeAggregate->getNodeName(),
-                        $command->getNewParentNodeAggregateIdentifier(),
-                        $affectedDimensionSpacePoints
-                    );
-                }
+                $this->requireNodeNameToBeUncovered(
+                    $command->getContentStreamIdentifier(),
+                    $nodeAggregate->getNodeName(),
+                    $command->getNewParentNodeAggregateIdentifier(),
+                    $affectedDimensionSpacePoints
+                );
 
                 $newParentNodeAggregate = $this->requireProjectedNodeAggregate($command->getContentStreamIdentifier(), $command->getNewParentNodeAggregateIdentifier());
 

--- a/Neos.EventSourcedContentRepository/Classes/Domain/Context/NodeAggregate/Feature/NodeMove.php
+++ b/Neos.EventSourcedContentRepository/Classes/Domain/Context/NodeAggregate/Feature/NodeMove.php
@@ -96,12 +96,14 @@ trait NodeMove
                     [$command->getNewParentNodeAggregateIdentifier()]
                 );
 
-                $this->requireNodeNameToBeUncovered(
-                    $command->getContentStreamIdentifier(),
-                    $nodeAggregate->getNodeName(),
-                    $command->getNewParentNodeAggregateIdentifier(),
-                    $affectedDimensionSpacePoints
-                );
+                if ($nodeAggregate->getNodeName() !== null) {
+                    $this->requireNodeNameToBeUncovered(
+                        $command->getContentStreamIdentifier(),
+                        $nodeAggregate->getNodeName(),
+                        $command->getNewParentNodeAggregateIdentifier(),
+                        $affectedDimensionSpacePoints
+                    );
+                }
 
                 $newParentNodeAggregate = $this->requireProjectedNodeAggregate($command->getContentStreamIdentifier(), $command->getNewParentNodeAggregateIdentifier());
 

--- a/Neos.EventSourcedContentRepository/Classes/Domain/Context/NodeAggregate/Feature/NodeRetyping.php
+++ b/Neos.EventSourcedContentRepository/Classes/Domain/Context/NodeAggregate/Feature/NodeRetyping.php
@@ -64,9 +64,9 @@ trait NodeRetyping
 
     abstract protected function areNodeTypeConstraintsImposedByParentValid(NodeType $parentsNodeType, ?NodeName $nodeName, NodeType $nodeType): bool;
 
-    abstract protected function requireNodeTypeConstraintsImposedByGrandparentToBeMet(NodeType $grandParentsNodeType, NodeName $parentNodeName, NodeType $nodeType): void;
+    abstract protected function requireNodeTypeConstraintsImposedByGrandparentToBeMet(NodeType $grandParentsNodeType, ?NodeName $parentNodeName, NodeType $nodeType): void;
 
-    abstract protected function areNodeTypeConstraintsImposedByGrandparentValid(NodeType $grandParentsNodeType, NodeName $parentNodeName, NodeType $nodeType): bool;
+    abstract protected function areNodeTypeConstraintsImposedByGrandparentValid(NodeType $grandParentsNodeType, ?NodeName $parentNodeName, NodeType $nodeType): bool;
 
     abstract protected static function populateNodeAggregateIdentifiers(NodeType $nodeType, NodeAggregateIdentifiersByNodePaths $nodeAggregateIdentifiers, NodePath $childPath = null): NodeAggregateIdentifiersByNodePaths;
 

--- a/Neos.EventSourcedContentRepository/Classes/Domain/Context/NodeDuplication/Command/CopyNodesRecursively.php
+++ b/Neos.EventSourcedContentRepository/Classes/Domain/Context/NodeDuplication/Command/CopyNodesRecursively.php
@@ -100,8 +100,8 @@ final class CopyNodesRecursively implements \JsonSerializable, MatchableWithNode
      * @param OriginDimensionSpacePoint $targetDimensionSpacePoint
      * @param UserIdentifier $initiatingUserIdentifier
      * @param NodeAggregateIdentifier $targetParentNodeAggregateIdentifier
-     * @param NodeAggregateIdentifier $targetSucceedingSiblingNodeAggregateIdentifier
-     * @param NodeName $targetNodeName
+     * @param NodeAggregateIdentifier|null $targetSucceedingSiblingNodeAggregateIdentifier
+     * @param NodeName|null $targetNodeName
      * @param NodeAggregateIdentifierMapping $nodeAggregateIdentifierMapping
      */
     private function __construct(ContentStreamIdentifier $contentStreamIdentifier, NodeSubtreeSnapshot $nodeToInsert, OriginDimensionSpacePoint $targetDimensionSpacePoint, UserIdentifier $initiatingUserIdentifier, NodeAggregateIdentifier $targetParentNodeAggregateIdentifier, ?NodeAggregateIdentifier $targetSucceedingSiblingNodeAggregateIdentifier, ?NodeName $targetNodeName, NodeAggregateIdentifierMapping $nodeAggregateIdentifierMapping)

--- a/Neos.EventSourcedContentRepository/Classes/Domain/Context/NodeDuplication/Command/Dto/NodeSubtreeSnapshot.php
+++ b/Neos.EventSourcedContentRepository/Classes/Domain/Context/NodeDuplication/Command/Dto/NodeSubtreeSnapshot.php
@@ -73,7 +73,7 @@ final class NodeSubtreeSnapshot implements \JsonSerializable
      * NodeToInsert constructor.
      * @param NodeAggregateIdentifier $nodeAggregateIdentifier
      * @param NodeTypeName $nodeTypeName
-     * @param NodeName $nodeName
+     * @param NodeName|null $nodeName
      * @param NodeAggregateClassification $nodeAggregateClassification
      * @param SerializedPropertyValues $propertyValues
      * @param NodeReferences $nodeReferences

--- a/Neos.EventSourcedContentRepository/Tests/Behavior/Features/EventSourced/NodeMove/MoveNodeAggregate.feature
+++ b/Neos.EventSourcedContentRepository/Tests/Behavior/Features/EventSourced/NodeMove/MoveNodeAggregate.feature
@@ -162,6 +162,30 @@ Feature: Move node to a new parent / within the current parent before a sibling 
       | relationDistributionStrategy     | "scatter"                          |
     Then the last command should have thrown an exception of type "NodeNameIsAlreadyCovered"
 
+  Scenario: Move a node that has no name
+    Given the event NodeAggregateWithNodeWasCreated was published with payload:
+      | Key                           | Value                                                                                                                                              |
+      | contentStreamIdentifier       | "cs-identifier"                                                                                                                                    |
+      | nodeAggregateIdentifier       | "nody-mc-nodeface"                                                                                                                                 |
+      | nodeTypeName                  | "Neos.ContentRepository.Testing:Document"                                                                                                          |
+      | originDimensionSpacePoint     | {"market": "DE", "language": "de"}                                                                                                                 |
+      | coveredDimensionSpacePoints   | [{"market": "DE", "language": "de"}, {"market": "DE", "language": "gsw"}, {"market": "CH", "language": "de"}, {"market": "CH", "language": "gsw"}] |
+      | parentNodeAggregateIdentifier | "sir-david-nodenborough"                                                                                                                           |
+      | nodeAggregateClassification   | "regular"                                                                                                                                          |
+    And the graph projection is fully up to date
+
+    When the command MoveNodeAggregate is executed with payload:
+      | Key                              | Value                              |
+      | contentStreamIdentifier          | "cs-identifier"                    |
+      | dimensionSpacePoint              | {"market": "DE", "language": "de"} |
+      | nodeAggregateIdentifier          | "nody-mc-nodeface"                 |
+      | newParentNodeAggregateIdentifier | "lady-eleonode-rootford"           |
+      | relationDistributionStrategy     | "scatter"                          |
+    And the graph projection is fully up to date
+    When I am in content stream "cs-identifier" and Dimension Space Point {"market": "DE", "language": "de"}
+    And I expect node aggregate identifier "nody-mc-nodeface" to lead to node {"contentStreamIdentifier":"cs-identifier","nodeAggregateIdentifier":"nody-mc-nodeface","originDimensionSpacePoint":{"market":"DE","language":"de"}}
+
+
   Scenario: Try to move a node to a parent whose node type does not allow child nodes of the node's type
     Given the event NodeAggregateWithNodeWasCreated was published with payload:
       | Key                           | Value                                                                                                                                              |


### PR DESCRIPTION
Without this fix trying to move a node that has no `NodeName` set leads
to an exception:

    Argument 2 passed to NodeAggregateCommandHandler::requireNodeNameToBeUncovered() must
    be an instance of NodeName, null given, called in NodeMove.php on line 100