### PR TITLE
Prevent legacy Node instantiation

### DIFF
--- a/Neos.EventSourcedNeosAdjustments/Patches/neos_neos-development-collection_prevent_legacy_node_instantiation.patch
+++ b/Neos.EventSourcedNeosAdjustments/Patches/neos_neos-development-collection_prevent_legacy_node_instantiation.patch
@@ -1,0 +1,12 @@
+diff --git a/Neos.ContentRepository/Classes/Domain/Model/Node.php b/Neos.ContentRepository/Classes/Domain/Model/Node.php
+index 551a73c27..ed255dacf 100644
+--- a/Neos.ContentRepository/Classes/Domain/Model/Node.php
++++ b/Neos.ContentRepository/Classes/Domain/Model/Node.php
+@@ -106,6 +106,7 @@ class Node implements NodeInterface, CacheAwareInterface, TraversableNodeInterfa
+      */
+     public function __construct(NodeData $nodeData, Context $context)
+     {
++        throw new \Neos\Flow\Exception(sprintf('A %s legacy node was instantiated, but that is no longer supported, please check the backtrace', __CLASS__), 1613401289);
+         $this->nodeData = $nodeData;
+         $this->context = $context;
+     }

--- a/Neos.EventSourcedNeosAdjustments/composer.patches.json
+++ b/Neos.EventSourcedNeosAdjustments/composer.patches.json
@@ -2,7 +2,8 @@
   "patches": {
     "neos/neos-development-collection": {
       "neos_neos-development-collection_ReadMe": "Packages/CR/Neos.EventSourcedNeosAdjustments/Patches/neos_neos-development-collection_ReadMe.patch",
-      "neos_neos-development-collection_upload-asset": "Packages/CR/Neos.EventSourcedNeosAdjustments/Patches/neos_neos-development-collection_upload-asset.patch"
+      "neos_neos-development-collection_upload-asset": "Packages/CR/Neos.EventSourcedNeosAdjustments/Patches/neos_neos-development-collection_upload-asset.patch",
+      "neos_neos-development-collection_prevent_legacy_node_instantiation": "Packages/CR/Neos.EventSourcedNeosAdjustments/Patches/neos_neos-development-collection_prevent_legacy_node_instantiation.patch"
     }
   }
 }


### PR DESCRIPTION
Adds a composer patch file that prevents legacy nodes from
being instantiated by introducing an exception to the
`\Neos\ContentRepository\Domain\Model\Node` constructor.

Fixes: #183