### PR TITLE
Feature/160/traversable node as extension point

### DIFF
--- a/Neos.EventSourcedContentRepository.LegacyApi/Classes/FlowQueryContextOperation/ContextOperation.php
+++ b/Neos.EventSourcedContentRepository.LegacyApi/Classes/FlowQueryContextOperation/ContextOperation.php
@@ -101,7 +101,7 @@ class ContextOperation extends AbstractOperation
 
             $nodeInModifiedSubgraph = $subgraph->findNodeByNodeAggregateIdentifier($contextNode->getNodeAggregateIdentifier());
             if ($nodeInModifiedSubgraph !== null) {
-                $output[$nodeInModifiedSubgraph->getNodeAggregateIdentifier()->jsonSerialize()] = new TraversableNode($nodeInModifiedSubgraph, $subgraph);
+                $output[$nodeInModifiedSubgraph->getNodeAggregateIdentifier()->jsonSerialize()] = $nodeInModifiedSubgraph;
             }
         }
 

--- a/Neos.EventSourcedContentRepository/Classes/Domain/Context/NodeAggregate/NodeAggregateCommandHandler.php
+++ b/Neos.EventSourcedContentRepository/Classes/Domain/Context/NodeAggregate/NodeAggregateCommandHandler.php
@@ -204,14 +204,14 @@ final class NodeAggregateCommandHandler
             if (!$parentsNodeType->allowsChildNodeType($newNodeType)) {
                 throw new NodeConstraintException('Node type ' . $command->getNewNodeTypeName() . ' is not allowed below nodes of type ' . $parentAggregate->getNodeTypeName());
             }
-            if ($nodeAggregate->getNodeName()
+            if ($nodeAggregate->isNamed()
                 && $parentsNodeType->hasAutoCreatedChildNode($nodeAggregate->getNodeName())
                 && $parentsNodeType->getTypeOfAutoCreatedChildNode($nodeAggregate->getNodeName())->getName() !== (string)$command->getNewNodeTypeName()) {
                 throw new NodeConstraintException('Cannot change type of auto created child node' . $nodeAggregate->getNodeName() . ' to ' . $command->getNewNodeTypeName());
             }
             foreach ($this->contentGraph->findParentNodeAggregates($command->getContentStreamIdentifier(), $parentAggregate->getIdentifier()) as $grandParentAggregate) {
                 $grandParentsNodeType = $this->nodeTypeManager->getNodeType((string)$grandParentAggregate->getNodeTypeName());
-                if ($parentAggregate->getNodeName()
+                if ($parentAggregate->isNamed()
                     && $grandParentsNodeType->hasAutoCreatedChildNode($parentAggregate->getNodeName())
                     && !$grandParentsNodeType->allowsGrandchildNodeType((string) $parentAggregate->getNodeName(), $newNodeType)) {
                     throw new NodeConstraintException('Node type "' . $command->getNewNodeTypeName() . '" is not allowed below auto created child nodes "' . $parentAggregate->getNodeName()
@@ -242,10 +242,10 @@ final class NodeAggregateCommandHandler
                 }
             }
 
-            if ($childAggregate->getNodeName() && $newNodeType->hasAutoCreatedChildNode($childAggregate->getNodeName())) {
+            if ($childAggregate->isNamed() && $newNodeType->hasAutoCreatedChildNode($childAggregate->getNodeName())) {
                 foreach ($this->contentGraph->findChildNodeAggregates($command->getContentStreamIdentifier(), $childAggregate->getIdentifier()) as $grandChildAggregate) {
                     $grandChildsNodeType = $this->nodeTypeManager->getNodeType((string)$grandChildAggregate->getNodeTypeName());
-                    if ($childAggregate->getNodeName() && !$newNodeType->allowsGrandchildNodeType((string)$childAggregate->getNodeName(), $grandChildsNodeType)) {
+                    if ($childAggregate->isNamed() && !$newNodeType->allowsGrandchildNodeType((string)$childAggregate->getNodeName(), $grandChildsNodeType)) {
                         if (!$command->getStrategy()) {
                             throw new NodeConstraintException('Node type ' . $command->getNewNodeTypeName() . ' does not allow auto created child nodes "' . $childAggregate->getNodeName()
                                 . '" to have children of type  ' . $grandChildAggregate->getNodeTypeName() . ', which already exist. Please choose a resolution strategy.', 1520151998);

--- a/Neos.EventSourcedContentRepository/Classes/Domain/Context/NodeAggregate/NodeImplementationClassName.php
+++ b/Neos.EventSourcedContentRepository/Classes/Domain/Context/NodeAggregate/NodeImplementationClassName.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\EventSourcedContentRepository\Domain\Context\NodeAggregate;
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\ContentRepository\Domain\Model\NodeInterface as LegacyNodeInterface;
+use Neos\ContentRepository\Domain\Model\NodeType;
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
+use Neos\ContentRepository\Exception\NodeConfigurationException;
+use Neos\EventSourcedContentRepository\Domain\Projection\Content\TraversableNode;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * The node implementation class name resolver
+ *
+ * @Flow\Proxy(false)
+ */
+final class NodeImplementationClassName
+{
+    /**
+     * @param NodeType $nodeType
+     * @return string
+     * @throws NodeConfigurationException
+     */
+    public static function forNodeType(NodeType $nodeType): string
+    {
+        $customClassName = $nodeType->getConfiguration('class');
+        if (!empty($customClassName)) {
+            if (!class_exists($customClassName)) {
+                throw new NodeConfigurationException(
+                    'The configured implementation class name "' . $customClassName . '" for NodeType "' . $nodeType . '" does not exist.',
+                    1505805774
+                );
+            }
+
+            $implementedInterfaces = class_implements($customClassName);
+            if (!in_array(TraversableNodeInterface::class, $implementedInterfaces)) {
+                if (in_array(LegacyNodeInterface::class, $implementedInterfaces)) {
+                    throw new NodeConfigurationException('The configured implementation class name "' . $customClassName . '" for NodeType "' . $nodeType. '" inherits from the OLD (pre-event-sourced) NodeInterface; which is not supported anymore. Your custom Node class now needs to implement ' . TraversableNodeInterface::class . '.', 1520069750);
+                }
+                throw new NodeConfigurationException('The configured implementation class name "' . $customClassName . '" for NodeType "' . $nodeType. '" does not inherit from ' . TraversableNodeInterface::class . '.', 1406884014);
+            }
+
+            return $customClassName;
+        } else {
+            return TraversableNode::class;
+        }
+    }
+}

--- a/Neos.EventSourcedContentRepository/Classes/Domain/Context/StructureAdjustment/DisallowedChildNodeAdjustment.php
+++ b/Neos.EventSourcedContentRepository/Classes/Domain/Context/StructureAdjustment/DisallowedChildNodeAdjustment.php
@@ -71,7 +71,6 @@ class DisallowedChildNodeAdjustment
                 $parentNode = $subgraph->findParentNode($nodeAggregate->getIdentifier());
                 $grandparentNode = $parentNode !== null ? $subgraph->findParentNode($parentNode->getNodeAggregateIdentifier()) : null;
 
-
                 $allowedByParent = true;
                 $parentNodeType = null;
                 if ($parentNode !== null) {

--- a/Neos.EventSourcedContentRepository/Classes/Domain/Projection/Content/ContentSubgraphInterface.php
+++ b/Neos.EventSourcedContentRepository/Classes/Domain/Projection/Content/ContentSubgraphInterface.php
@@ -13,12 +13,13 @@ namespace Neos\EventSourcedContentRepository\Domain\Projection\Content;
  */
 
 use Neos\ContentRepository\DimensionSpace\DimensionSpace\DimensionSpacePoint;
-use Neos\ContentRepository\Domain\Projection\Content\NodeInterface;
 use Neos\ContentRepository\Domain\ContentStream\ContentStreamIdentifier;
 use Neos\ContentRepository\Domain\NodeAggregate\NodeAggregateIdentifier;
 use Neos\ContentRepository\Domain\NodeAggregate\NodeName;
 use Neos\ContentRepository\Domain\ContentSubgraph\NodePath;
 use Neos\ContentRepository\Domain\NodeType\NodeTypeConstraints;
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodes;
 use Neos\EventSourcedContentRepository\Domain\Context\ContentSubgraph\SubtreeInterface;
 use Neos\EventSourcedContentRepository\Domain\ValueObject\PropertyName;
 
@@ -27,110 +28,73 @@ use Neos\EventSourcedContentRepository\Domain\ValueObject\PropertyName;
  */
 interface ContentSubgraphInterface extends \JsonSerializable
 {
-    /**
-     * @param NodeAggregateIdentifier $nodeAggregateIdentifier
-     * @param NodeTypeConstraints $nodeTypeConstraints
-     * @param int|null $limit
-     * @param int|null $offset
-     * @return array|NodeInterface[]
-     */
-    public function findChildNodes(NodeAggregateIdentifier $nodeAggregateIdentifier, NodeTypeConstraints $nodeTypeConstraints = null, int $limit = null, int $offset = null): array;
+    public function findChildNodes(
+        NodeAggregateIdentifier $nodeAggregateIdentifier,
+        NodeTypeConstraints $nodeTypeConstraints = null,
+        int $limit = null,
+        int $offset = null
+    ): TraversableNodes;
 
-    /**
-     * @param NodeAggregateIdentifier $nodeAggregateAggregateIdentifier
-     * @param PropertyName|null $name
-     * @return NodeInterface[]
-     */
-    public function findReferencedNodes(NodeAggregateIdentifier $nodeAggregateAggregateIdentifier, PropertyName $name = null): array;
+    public function findReferencedNodes(
+        NodeAggregateIdentifier $nodeAggregateAggregateIdentifier,
+        PropertyName $name = null
+    ): TraversableNodes;
 
-    /**
-     * @param NodeAggregateIdentifier $nodeAggregateIdentifier
-     * @param PropertyName $name
-     * @return NodeInterface[]
-     */
-    public function findReferencingNodes(NodeAggregateIdentifier $nodeAggregateIdentifier, PropertyName $name = null): array;
+    public function findReferencingNodes(
+        NodeAggregateIdentifier $nodeAggregateIdentifier,
+        PropertyName $name = null
+    ): TraversableNodes;
 
-    /**
-     * @param NodeAggregateIdentifier $nodeAggregateIdentifier
-     * @return NodeInterface|null
-     */
-    public function findNodeByNodeAggregateIdentifier(NodeAggregateIdentifier $nodeAggregateIdentifier): ?NodeInterface;
+    public function findNodeByNodeAggregateIdentifier(NodeAggregateIdentifier $nodeAggregateIdentifier): ?TraversableNodeInterface;
 
-    /**
-     * @param NodeAggregateIdentifier $parentNodeAggregateIdentifier
-     * @param NodeTypeConstraints|null $nodeTypeConstraints
-     * @return int
-     */
-    public function countChildNodes(NodeAggregateIdentifier $parentNodeAggregateIdentifier, NodeTypeConstraints $nodeTypeConstraints = null): int;
+    public function countChildNodes(
+        NodeAggregateIdentifier $parentNodeAggregateIdentifier,
+        NodeTypeConstraints $nodeTypeConstraints = null
+    ): int;
 
-    /**
-     * @param NodeAggregateIdentifier $childAggregateIdentifier
-     * @return NodeInterface|null
-     */
-    public function findParentNode(NodeAggregateIdentifier $childAggregateIdentifier): ?NodeInterface;
+    public function findParentNode(NodeAggregateIdentifier $childAggregateIdentifier): ?TraversableNodeInterface;
 
-    /**
-     * @param NodePath $path
-     * @param NodeAggregateIdentifier $startingNodeAggregateIdentifier
-     * @return NodeInterface|null
-     */
-    public function findNodeByPath(NodePath $path, NodeAggregateIdentifier $startingNodeAggregateIdentifier): ?NodeInterface;
+    public function findNodeByPath(
+        NodePath $path,
+        NodeAggregateIdentifier $startingNodeAggregateIdentifier
+    ): ?TraversableNodeInterface;
 
-    /**
-     * @param NodeAggregateIdentifier $parentNodeAggregateIdentifier
-     * @param NodeName $edgeName
-     * @return NodeInterface|null
-     */
-    public function findChildNodeConnectedThroughEdgeName(NodeAggregateIdentifier $parentNodeAggregateIdentifier, NodeName $edgeName): ?NodeInterface;
+    public function findChildNodeConnectedThroughEdgeName(
+        NodeAggregateIdentifier $parentNodeAggregateIdentifier,
+        NodeName $edgeName
+    ): ?TraversableNodeInterface;
 
-    /**
-     * @param NodeAggregateIdentifier $sibling
-     * @param NodeTypeConstraints|null $nodeTypeConstraints
-     * @param int|null $limit
-     * @param int|null $offset
-     * @return array|NodeInterface[]
-     */
-    public function findSiblings(NodeAggregateIdentifier $sibling, ?NodeTypeConstraints $nodeTypeConstraints = null, int $limit = null, int $offset = null): array;
+    public function findSiblings(
+        NodeAggregateIdentifier $sibling,
+        ?NodeTypeConstraints $nodeTypeConstraints = null,
+        int $limit = null,
+        int $offset = null
+    ): TraversableNodes;
 
-    /**
-     * @param NodeAggregateIdentifier $sibling
-     * @param NodeTypeConstraints|null $nodeTypeConstraints
-     * @param int|null $limit
-     * @param int|null $offset
-     * @return array|NodeInterface[]
-     */
-    public function findSucceedingSiblings(NodeAggregateIdentifier $sibling, ?NodeTypeConstraints $nodeTypeConstraints = null, int $limit = null, int $offset = null): array;
+    public function findSucceedingSiblings(
+        NodeAggregateIdentifier $sibling,
+        ?NodeTypeConstraints $nodeTypeConstraints = null,
+        int $limit = null,
+        int $offset = null
+    ): TraversableNodes;
 
-    /**
-     * @param NodeAggregateIdentifier $sibling
-     * @param NodeTypeConstraints|null $nodeTypeConstraints
-     * @param int|null $limit
-     * @param int|null $offset
-     * @return array|NodeInterface[]
-     */
-    public function findPrecedingSiblings(NodeAggregateIdentifier $sibling, ?NodeTypeConstraints $nodeTypeConstraints = null, int $limit = null, int $offset = null): array;
+    public function findPrecedingSiblings(
+        NodeAggregateIdentifier $sibling,
+        ?NodeTypeConstraints $nodeTypeConstraints = null,
+        int $limit = null, int $offset = null
+    ): TraversableNodes;
 
-    /**
-     * @param NodeAggregateIdentifier $nodeAggregateIdentifier
-     * @return NodePath
-     */
     public function findNodePath(NodeAggregateIdentifier $nodeAggregateIdentifier): NodePath;
 
-    /**
-     * @return ContentStreamIdentifier
-     */
     public function getContentStreamIdentifier(): ContentStreamIdentifier;
 
-    /**
-     * @return DimensionSpacePoint
-     */
     public function getDimensionSpacePoint(): DimensionSpacePoint;
 
     /**
      * @param NodeAggregateIdentifier[] $entryNodeAggregateIdentifiers
      * @param int $maximumLevels
      * @param NodeTypeConstraints $nodeTypeConstraints
-     * @return mixed
+     * @return SubtreeInterface
      */
     public function findSubtrees(array $entryNodeAggregateIdentifiers, int $maximumLevels, NodeTypeConstraints $nodeTypeConstraints): SubtreeInterface;
 
@@ -142,9 +106,9 @@ interface ContentSubgraphInterface extends \JsonSerializable
      * @param array $entryNodeAggregateIdentifiers
      * @param NodeTypeConstraints $nodeTypeConstraints
      * @param SearchTerm|null $searchTerm
-     * @return array|NodeInterface[]
+     * @return TraversableNodes
      */
-    public function findDescendants(array $entryNodeAggregateIdentifiers, NodeTypeConstraints $nodeTypeConstraints, ?SearchTerm $searchTerm): array;
+    public function findDescendants(array $entryNodeAggregateIdentifiers, NodeTypeConstraints $nodeTypeConstraints, ?SearchTerm $searchTerm): TraversableNodes;
 
     public function countNodes(): int;
 

--- a/Neos.EventSourcedContentRepository/Classes/Domain/Projection/Content/InMemoryCache/AllChildNodesByNodeIdentifierCache.php
+++ b/Neos.EventSourcedContentRepository/Classes/Domain/Projection/Content/InMemoryCache/AllChildNodesByNodeIdentifierCache.php
@@ -16,6 +16,7 @@ namespace Neos\EventSourcedContentRepository\Domain\Projection\Content\InMemoryC
 use Neos\ContentRepository\Domain\Projection\Content\NodeInterface;
 use Neos\ContentRepository\Domain\NodeAggregate\NodeAggregateIdentifier;
 use Neos\ContentRepository\Domain\NodeType\NodeTypeConstraints;
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodes;
 
 /**
  * This cache is only filled for a $parentNodeIdentifier if we have retrieved *all* childNodes, without any restriction.
@@ -34,7 +35,7 @@ final class AllChildNodesByNodeIdentifierCache
         $this->isEnabled = $isEnabled;
     }
 
-    public function add(NodeAggregateIdentifier $parentNodeAggregateIdentifier, ?NodeTypeConstraints $nodeTypeConstraints, array $allChildNodes): void
+    public function add(NodeAggregateIdentifier $parentNodeAggregateIdentifier, ?NodeTypeConstraints $nodeTypeConstraints, TraversableNodes $allChildNodes): void
     {
         if ($this->isEnabled === false) {
             return;
@@ -56,10 +57,15 @@ final class AllChildNodesByNodeIdentifierCache
         return isset($this->childNodes[$key][$nodeTypeConstraintsSerialized]) || isset($this->childNodes[$key]['*']);
     }
 
-    public function findChildNodes(NodeAggregateIdentifier $parentNodeAggregateIdentifier, NodeTypeConstraints $nodeTypeConstraints = null, int $limit = null, int $offset = null): array
-    {
+    public function findChildNodes(
+        NodeAggregateIdentifier
+        $parentNodeAggregateIdentifier,
+        NodeTypeConstraints $nodeTypeConstraints = null,
+        int $limit = null,
+        int $offset = null
+    ): TraversableNodes {
         if ($this->isEnabled === false) {
-            return [];
+            TraversableNodes::fromArray([]);
         }
 
         $key = (string)$parentNodeAggregateIdentifier;
@@ -83,6 +89,7 @@ final class AllChildNodesByNodeIdentifierCache
                 $result = array_slice($result, $offset ?? 0, $limit);
             }
         }
-        return $result;
+
+        return TraversableNodes::fromArray($result);
     }
 }

--- a/Neos.EventSourcedContentRepository/Classes/Domain/Projection/Content/InMemoryCache/NamedChildNodeByNodeIdentifierCache.php
+++ b/Neos.EventSourcedContentRepository/Classes/Domain/Projection/Content/InMemoryCache/NamedChildNodeByNodeIdentifierCache.php
@@ -13,9 +13,9 @@ namespace Neos\EventSourcedContentRepository\Domain\Projection\Content\InMemoryC
  * source code.
  */
 
-use Neos\ContentRepository\Domain\Projection\Content\NodeInterface;
 use Neos\ContentRepository\Domain\NodeAggregate\NodeAggregateIdentifier;
 use Neos\ContentRepository\Domain\NodeAggregate\NodeName;
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
 
 /**
  * Parent Node Identifier + Node Name => Child Node
@@ -41,7 +41,7 @@ final class NamedChildNodeByNodeIdentifierCache
         $this->isEnabled = $isEnabled;
     }
 
-    public function add(NodeAggregateIdentifier $parentNodeAggregateIdentifier, ?NodeName $nodeName, NodeInterface $node): void
+    public function add(NodeAggregateIdentifier $parentNodeAggregateIdentifier, ?NodeName $nodeName, TraversableNodeInterface $node): void
     {
         if ($this->isEnabled === false) {
             return;
@@ -63,7 +63,7 @@ final class NamedChildNodeByNodeIdentifierCache
         return isset($this->nodes[(string)$parentNodeAggregateIdentifier][(string)$nodeName]);
     }
 
-    public function get(NodeAggregateIdentifier $parentNodeAggregateIdentifier, NodeName $nodeName): ?NodeInterface
+    public function get(NodeAggregateIdentifier $parentNodeAggregateIdentifier, NodeName $nodeName): ?TraversableNodeInterface
     {
         if ($this->isEnabled === false) {
             return null;

--- a/Neos.EventSourcedContentRepository/Classes/Domain/Projection/Content/InMemoryCache/NodeByNodeAggregateIdentifierCache.php
+++ b/Neos.EventSourcedContentRepository/Classes/Domain/Projection/Content/InMemoryCache/NodeByNodeAggregateIdentifierCache.php
@@ -15,6 +15,7 @@ namespace Neos\EventSourcedContentRepository\Domain\Projection\Content\InMemoryC
 
 use Neos\ContentRepository\Domain\NodeAggregate\NodeAggregateIdentifier;
 use Neos\ContentRepository\Domain\Projection\Content\NodeInterface;
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
 
 /**
  * NodeAggregateIdentifier -> Node cache
@@ -49,7 +50,7 @@ final class NodeByNodeAggregateIdentifierCache
         return isset($this->nodes[$key]) || isset($this->nonExistingNodeAggregateIdentifiers[$key]);
     }
 
-    public function add(NodeAggregateIdentifier $nodeAggregateIdentifier, NodeInterface $node): void
+    public function add(NodeAggregateIdentifier $nodeAggregateIdentifier, TraversableNodeInterface $node): void
     {
         if ($this->isEnabled === false) {
             return;
@@ -69,7 +70,7 @@ final class NodeByNodeAggregateIdentifierCache
         $this->nonExistingNodeAggregateIdentifiers[$key] = true;
     }
 
-    public function get(NodeAggregateIdentifier $nodeAggregateIdentifier): ?NodeInterface
+    public function get(NodeAggregateIdentifier $nodeAggregateIdentifier): ?TraversableNodeInterface
     {
         if ($this->isEnabled === false) {
             return null;

--- a/Neos.EventSourcedContentRepository/Classes/Domain/Projection/Content/NodeAggregate.php
+++ b/Neos.EventSourcedContentRepository/Classes/Domain/Projection/Content/NodeAggregate.php
@@ -171,6 +171,11 @@ final class NodeAggregate implements ReadableNodeAggregateInterface
         return $this->nodeName;
     }
 
+    public function isNamed(): bool
+    {
+        return $this->nodeName instanceof NodeName;
+    }
+
     public function getOccupiedDimensionSpacePoints(): OriginDimensionSpacePointSet
     {
         return $this->occupiedDimensionSpacePoints;
@@ -251,7 +256,6 @@ final class NodeAggregate implements ReadableNodeAggregateInterface
     {
         return $this->disabledDimensionSpacePoints->contains($dimensionSpacePoint);
     }
-
 
     public function getClassification(): NodeAggregateClassification
     {

--- a/Neos.EventSourcedContentRepository/Classes/Domain/Projection/Content/NodeTreeTraversalHelper.php
+++ b/Neos.EventSourcedContentRepository/Classes/Domain/Projection/Content/NodeTreeTraversalHelper.php
@@ -20,7 +20,6 @@ use Neos\ContentRepository\Domain\NodeAggregate\NodeAggregateIdentifier;
 
 final class NodeTreeTraversalHelper
 {
-
     /**
      * the callback always gets the current NodeInterface passed as first parameter, and then its parent, and its parent etc etc.
      * Until it has reached the root, or the return value of the closure is FALSE.
@@ -47,13 +46,11 @@ final class NodeTreeTraversalHelper
 
         $childNodeAggregateIdentifier = self::findNodeAggregateIdentifierByPath($subgraph, $nodeAggregateIdentifier, $nodePath);
         if ($childNodeAggregateIdentifier !== null) {
-            $node = $subgraph->findNodeByNodeAggregateIdentifier($childNodeAggregateIdentifier);
-            return new TraversableNode($node, $subgraph);
+            return $subgraph->findNodeByNodeAggregateIdentifier($childNodeAggregateIdentifier);
         }
 
         return null;
     }
-
 
     private static function findRootNodeAggregateIdentifier(ContentSubgraphInterface $subgraph, NodeAggregateIdentifier $nodeAggregateIdentifier): NodeAggregateIdentifier
     {

--- a/Neos.EventSourcedContentRepository/Classes/Domain/Projection/Content/TraversableNode.php
+++ b/Neos.EventSourcedContentRepository/Classes/Domain/Projection/Content/TraversableNode.php
@@ -45,20 +45,21 @@ final class TraversableNode implements TraversableNodeInterface, ProtectedContex
 
     public function findParentNode(): TraversableNodeInterface
     {
-        $node = $this->subgraph->findParentNode($this->node->getNodeAggregateIdentifier());
+        $node = $this->subgraph->findParentNode($this->getNodeAggregateIdentifier());
         if ($node === null) {
             throw new NodeException('This node has no parent', 1542982973);
         }
-        return new TraversableNode($node, $this->subgraph);
+        return $node;
     }
 
     public function findNamedChildNode(NodeName $nodeName): TraversableNodeInterface
     {
-        $node = $this->subgraph->findChildNodeConnectedThroughEdgeName($this->node->getNodeAggregateIdentifier(), $nodeName);
+        $node = $this->subgraph->findChildNodeConnectedThroughEdgeName($this->getNodeAggregateIdentifier(), $nodeName);
         if ($node === null) {
             throw new NodeException(sprintf('Child node with name "%s" does not exist', $nodeName), 1542982917);
         }
-        return new TraversableNode($node, $this->subgraph);
+
+        return $node;
     }
 
     /**
@@ -69,37 +70,27 @@ final class TraversableNode implements TraversableNodeInterface, ProtectedContex
      */
     public function findChildNodes(NodeTypeConstraints $nodeTypeConstraints = null, int $limit = null, int $offset = null): TraversableNodes
     {
-        $childNodes = $this->subgraph->findChildNodes($this->node->getNodeAggregateIdentifier(), $nodeTypeConstraints, $limit, $offset);
-
-        $traversableChildNodes = [];
-        foreach ($childNodes as $node) {
-            $traversableChildNodes[] = new TraversableNode($node, $this->subgraph);
-        }
-        return TraversableNodes::fromArray($traversableChildNodes);
+        return $this->subgraph->findChildNodes(
+            $this->getNodeAggregateIdentifier(),
+            $nodeTypeConstraints,
+            $limit,
+            $offset
+        );
     }
 
     public function countChildNodes(NodeTypeConstraints $nodeTypeConstraints = null): int
     {
-        return $this->subgraph->countChildNodes($this->node->getNodeAggregateIdentifier(), $nodeTypeConstraints);
+        return $this->subgraph->countChildNodes($this->getNodeAggregateIdentifier(), $nodeTypeConstraints);
     }
 
     public function findNodePath(): NodePath
     {
-        return $this->subgraph->findNodePath($this->node->getNodeAggregateIdentifier());
+        return $this->subgraph->findNodePath($this->getNodeAggregateIdentifier());
     }
 
-    /**
-     * @return TraversableNodes
-     */
     public function findReferencingNodes(): TraversableNodes
     {
-        $nodes = $this->subgraph->findReferencingNodes($this->node->getNodeAggregateIdentifier());
-
-        $traversableNodes = [];
-        foreach ($nodes as $node) {
-            $traversableNodes[] = new TraversableNode($node, $this->subgraph);
-        }
-        return TraversableNodes::fromArray($traversableNodes);
+        return $this->subgraph->findReferencingNodes($this->getNodeAggregateIdentifier());
     }
 
     /**
@@ -110,13 +101,7 @@ final class TraversableNode implements TraversableNodeInterface, ProtectedContex
      */
     public function findNamedReferencingNodes(PropertyName $edgeName): TraversableNodes
     {
-        $nodes = $this->subgraph->findReferencingNodes($this->node->getNodeAggregateIdentifier(), $edgeName);
-
-        $traversableNodes = [];
-        foreach ($nodes as $node) {
-            $traversableNodes[] = new TraversableNode($node, $this->subgraph);
-        }
-        return TraversableNodes::fromArray($traversableNodes);
+        return $this->subgraph->findReferencingNodes($this->getNodeAggregateIdentifier(), $edgeName);
     }
 
     /**
@@ -126,20 +111,14 @@ final class TraversableNode implements TraversableNodeInterface, ProtectedContex
      * @param NodeTypeConstraints|null $nodeTypeConstraints
      * @param int|null $limit
      * @param int|null $offset
-     * @return array<TraversableNodeInterface>|TraversableNodeInterface[]
+     * @return TraversableNodes
      */
     public function findSiblingNodes(
         NodeTypeConstraints $nodeTypeConstraints = null,
         int $limit = null,
         int $offset = null
-    ): array {
-        $nodes = $this->subgraph->findSiblings($this->node->getNodeAggregateIdentifier(), $nodeTypeConstraints, $limit, $offset);
-
-        $traversableNodes = [];
-        foreach ($nodes as $node) {
-            $traversableNodes[] = new TraversableNode($node, $this->subgraph);
-        }
-        return $traversableNodes;
+    ): TraversableNodes {
+        return $this->subgraph->findSiblings($this->getNodeAggregateIdentifier(), $nodeTypeConstraints, $limit, $offset);
     }
 
     /**
@@ -149,20 +128,14 @@ final class TraversableNode implements TraversableNodeInterface, ProtectedContex
      * @param NodeTypeConstraints|null $nodeTypeConstraints
      * @param int|null $limit
      * @param int|null $offset
-     * @return array
+     * @return TraversableNodes
      */
     public function findPrecedingSiblingNodes(
         NodeTypeConstraints $nodeTypeConstraints = null,
         int $limit = null,
         int $offset = null
-    ): array {
-        $nodes = $this->subgraph->findPrecedingSiblings($this->node->getNodeAggregateIdentifier());
-
-        $traversableNodes = [];
-        foreach ($nodes as $node) {
-            $traversableNodes[] = new TraversableNode($node, $this->subgraph);
-        }
-        return $traversableNodes;
+    ): TraversableNodes {
+        return $this->subgraph->findPrecedingSiblings($this->getNodeAggregateIdentifier(), $nodeTypeConstraints, $limit, $offset);
     }
 
     /**
@@ -172,20 +145,14 @@ final class TraversableNode implements TraversableNodeInterface, ProtectedContex
      * @param NodeTypeConstraints|null $nodeTypeConstraints
      * @param int|null $limit
      * @param int|null $offset
-     * @return array
+     * @return TraversableNodes
      */
     public function findSucceedingSiblingNodes(
         NodeTypeConstraints $nodeTypeConstraints = null,
         int $limit = null,
         int $offset = null
-    ): array {
-        $nodes = $this->subgraph->findSucceedingSiblings($this->node->getNodeAggregateIdentifier());
-
-        $traversableNodes = [];
-        foreach ($nodes as $node) {
-            $traversableNodes[] = new TraversableNode($node, $this->subgraph);
-        }
-        return $traversableNodes;
+    ): TraversableNodes {
+        return $this->subgraph->findSucceedingSiblings($this->getNodeAggregateIdentifier(), $nodeTypeConstraints, $limit, $offset);
     }
 
     /**
@@ -199,13 +166,7 @@ final class TraversableNode implements TraversableNodeInterface, ProtectedContex
      */
     public function findReferencedNodes(): TraversableNodes
     {
-        $nodes = $this->subgraph->findReferencedNodes($this->node->getNodeAggregateIdentifier());
-
-        $traversableNodes = [];
-        foreach ($nodes as $node) {
-            $traversableNodes[] = new TraversableNode($node, $this->subgraph);
-        }
-        return TraversableNodes::fromArray($traversableNodes);
+        return $this->subgraph->findReferencedNodes($this->getNodeAggregateIdentifier());
     }
 
     /**
@@ -216,13 +177,7 @@ final class TraversableNode implements TraversableNodeInterface, ProtectedContex
      */
     public function findNamedReferencedNodes(PropertyName $edgeName): TraversableNodes
     {
-        $nodes = $this->subgraph->findReferencedNodes($this->node->getNodeAggregateIdentifier(), $edgeName);
-
-        $traversableNodes = [];
-        foreach ($nodes as $node) {
-            $traversableNodes[] = new TraversableNode($node, $this->subgraph);
-        }
-        return TraversableNodes::fromArray($traversableNodes);
+        return $this->subgraph->findReferencedNodes($this->getNodeAggregateIdentifier(), $edgeName);
     }
 
     /**

--- a/Neos.EventSourcedContentRepository/Classes/TypeConverter/NewNodeConverter.php
+++ b/Neos.EventSourcedContentRepository/Classes/TypeConverter/NewNodeConverter.php
@@ -15,11 +15,9 @@ namespace Neos\EventSourcedContentRepository\TypeConverter;
 use Neos\EventSourcedContentRepository\Domain\Context\Parameters\VisibilityConstraints;
 use Neos\EventSourcedContentRepository\Domain\Projection\Content\ContentGraphInterface;
 use Neos\Flow\Annotations as Flow;
-use Neos\Flow\Property\PropertyMapper;
 use Neos\Flow\Property\PropertyMappingConfigurationInterface;
 use Neos\Flow\Property\TypeConverter\AbstractTypeConverter;
 use Neos\EventSourcedContentRepository\Domain\Context\NodeAddress\NodeAddressFactory;
-use Neos\Flow\Security\Context;
 
 /**
  * !!! Only needed for uncached Fusion segments; as in Fusion ContentCache, the PropertyMapper is used to serialize
@@ -59,14 +57,20 @@ class NewNodeConverter extends AbstractTypeConverter
      */
     protected $nodeAddressFactory;
 
-    /**
-     *
-     */
-    public function convertFrom($source, $targetType = null, array $subProperties = [], PropertyMappingConfigurationInterface $configuration = null)
-    {
+    public function convertFrom(
+        $source,
+        $targetType = null,
+        array $subProperties = [],
+        PropertyMappingConfigurationInterface $configuration = null
+    ) {
         $nodeAddress = $this->nodeAddressFactory->createFromUriString($source);
 
-        $subgraph = $this->contentGraph->getSubgraphByIdentifier($nodeAddress->getContentStreamIdentifier(), $nodeAddress->getDimensionSpacePoint(), VisibilityConstraints::withoutRestrictions());
+        $subgraph = $this->contentGraph->getSubgraphByIdentifier(
+            $nodeAddress->getContentStreamIdentifier(),
+            $nodeAddress->getDimensionSpacePoint(),
+            VisibilityConstraints::withoutRestrictions()
+        );
+
         return $subgraph->findNodeByNodeAggregateIdentifier($nodeAddress->getNodeAggregateIdentifier());
     }
 }

--- a/Neos.EventSourcedContentRepository/Tests/Behavior/Features/Bootstrap/EventSourcedTrait.php
+++ b/Neos.EventSourcedContentRepository/Tests/Behavior/Features/Bootstrap/EventSourcedTrait.php
@@ -1531,7 +1531,7 @@ trait EventSourcedTrait
         $subgraph = $this->contentGraph
             ->getSubgraphByIdentifier($this->contentStreamIdentifier, $this->dimensionSpacePoint, $this->visibilityConstraints);
         $nodes = $subgraph
-            ->findChildNodes($nodeAggregateIdentifier);
+            ->findChildNodes($nodeAggregateIdentifier)->toArray();
 
         $numberOfChildNodes = $subgraph
             ->countChildNodes($nodeAggregateIdentifier);

--- a/Neos.EventSourcedContentRepository/Tests/Behavior/Features/Bootstrap/EventSourcedTrait.php
+++ b/Neos.EventSourcedContentRepository/Tests/Behavior/Features/Bootstrap/EventSourcedTrait.php
@@ -155,7 +155,7 @@ trait EventSourcedTrait
     protected $rootNodeAggregateIdentifier;
 
     /**
-     * @var NodeInterface
+     * @var TraversableNodeInterface
      */
     protected $currentNode;
 
@@ -954,12 +954,10 @@ trait EventSourcedTrait
     /**
      * @When /^the command CopyNodesRecursively is executed, copying the current node aggregate with payload:$/
      */
-    public function theCommandCopynodesrecursivelyIsExecutedCopyingTheCurrentNodeAggregateWithPayload(TableNode $payloadTable)
+    public function theCommandCopyNodesRecursivelyIsExecutedCopyingTheCurrentNodeAggregateWithPayload(TableNode $payloadTable)
     {
         $commandArguments = $this->readPayloadTable($payloadTable);
-        $subgraph = $this->contentGraph->getSubgraphByIdentifier($this->contentStreamIdentifier, $this->dimensionSpacePoint, VisibilityConstraints::withoutRestrictions());
-        $currentTraversableNode = new TraversableNode($this->currentNode, $subgraph);
-        $commandArguments['nodeToInsert'] = json_decode(json_encode(NodeSubtreeSnapshot::fromTraversableNode($currentTraversableNode)), true);
+        $commandArguments['nodeToInsert'] = json_decode(json_encode(NodeSubtreeSnapshot::fromTraversableNode($this->currentNode)), true);
         $command = CopyNodesRecursively::fromArray($commandArguments);
         $this->lastCommandOrEventResult = $this->getNodeDuplicationCommandHandler()
             ->handleCopyNodesRecursively($command);

--- a/Neos.EventSourcedContentRepository/Tests/Unit/Domain/Context/NodeAggregate/NodeImplementationClassNameTest.php
+++ b/Neos.EventSourcedContentRepository/Tests/Unit/Domain/Context/NodeAggregate/NodeImplementationClassNameTest.php
@@ -1,0 +1,95 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\EventSourcedContentRepository\Domain\Context\NodeAggregate;
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\ContentRepository\Domain\Model\NodeType;
+use Neos\ContentRepository\Exception\NodeConfigurationException;
+use Neos\EventSourcedContentRepository\Domain\Projection\Content\TraversableNode;
+use Neos\EventSourcedContentRepository\Tests\Unit\Fixtures\ExtendedValidTraversableNode;
+use Neos\EventSourcedContentRepository\Tests\Unit\Fixtures\InvalidTraversableNode;
+use Neos\EventSourcedContentRepository\Tests\Unit\Fixtures\InvalidTraversableNodeWithLegacySupport;
+use Neos\EventSourcedContentRepository\Tests\Unit\Fixtures\ValidTraversableNode;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test cases for the node implementation class name resolver
+ */
+final class NodeImplementationClassNameTest extends TestCase
+{
+
+    /**
+     * @param NodeType $nodeType
+     * @param string $expectedClassName
+     * @dataProvider validNodeTypeProvider
+     * @throws NodeConfigurationException
+     */
+    public function testFromNodeTypeReturnsCorrectImplementationClassNameForValidParameters(NodeType $nodeType, string $expectedClassName): void
+    {
+        Assert::assertSame($expectedClassName, NodeImplementationClassName::forNodeType($nodeType));
+    }
+
+    public function validNodeTypeProvider(): array
+    {
+        return [
+            [
+                new NodeType('Neos.ContentRepository:Test', [], ['class' => ValidTraversableNode::class]),
+                ValidTraversableNode::class
+            ],
+            [
+                new NodeType('Neos.ContentRepository:Test', [], ['class' => ExtendedValidTraversableNode::class]),
+                ExtendedValidTraversableNode::class
+            ],
+            [
+                new NodeType('Neos.ContentRepository:Test', [], []),
+                TraversableNode::class
+            ],
+        ];
+    }
+
+    /**
+     * @param NodeType $nodeType
+     * @param string $expectedException
+     * @dataProvider invalidNodeTypeProvider
+     */
+    public function testFromNodeTypeThrowsExceptionForValidParameters(NodeType $nodeType, string $expectedException): void
+    {
+        $actualException = null;
+        try {
+            NodeImplementationClassName::forNodeType($nodeType);
+        } catch(\Exception $exception) {
+            $actualException = $exception;
+        }
+
+        Assert::assertInstanceOf($expectedException, $actualException);
+    }
+
+    public function invalidNodeTypeProvider(): array
+    {
+        return [
+            [
+                new NodeType('Neos.ContentRepository:Test', [], ['class' => '\\Neos\\ContentRepository\\Tests\\Unit\\Fixtures\\IDoNotExist']),
+                NodeConfigurationException::class
+            ],
+            [
+                new NodeType('Neos.ContentRepository:Test', [], ['class' => InvalidTraversableNode::class]),
+                NodeConfigurationException::class
+            ],
+            [
+                new NodeType('Neos.ContentRepository:Test', [], ['class' => InvalidTraversableNodeWithLegacySupport::class]),
+                NodeConfigurationException::class
+            ],
+        ];
+    }
+}

--- a/Neos.EventSourcedContentRepository/Tests/Unit/Fixtures/ExtendedValidTraversableNode.php
+++ b/Neos.EventSourcedContentRepository/Tests/Unit/Fixtures/ExtendedValidTraversableNode.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\EventSourcedContentRepository\Tests\Unit\Fixtures;
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * An extended valid traversable node implementation
+ *
+ * @Flow\Proxy(false)
+ */
+class ExtendedValidTraversableNode extends ValidTraversableNode
+{
+}

--- a/Neos.EventSourcedContentRepository/Tests/Unit/Fixtures/InvalidTraversableNode.php
+++ b/Neos.EventSourcedContentRepository/Tests/Unit/Fixtures/InvalidTraversableNode.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\EventSourcedContentRepository\Tests\Unit\Fixtures;
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * An invalid valid traversable node implementation
+ *
+ * @Flow\Proxy(false)
+ */
+class InvalidTraversableNode
+{
+}

--- a/Neos.EventSourcedContentRepository/Tests/Unit/Fixtures/InvalidTraversableNodeWithLegacySupport.php
+++ b/Neos.EventSourcedContentRepository/Tests/Unit/Fixtures/InvalidTraversableNodeWithLegacySupport.php
@@ -1,0 +1,273 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\EventSourcedContentRepository\Tests\Unit\Fixtures;
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\ContentRepository\Domain\Model\ArrayPropertyCollection;
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\ContentRepository\Domain\Model\NodeTemplate;
+use Neos\ContentRepository\Domain\Model\NodeType;
+use Neos\ContentRepository\Domain\Model\Workspace;
+use Neos\ContentRepository\Domain\Projection\Content\PropertyCollectionInterface;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * An invalid traversable node implementation supporting the legacy API
+ */
+class InvalidTraversableNodeWithLegacySupport implements NodeInterface
+{
+    public function getNodeType(): NodeType
+    {
+        return new NodeType('Neos.ContentRepository:Test', [], []);
+    }
+
+    public function getProperties(): PropertyCollectionInterface
+    {
+        return new ArrayPropertyCollection([]);
+    }
+
+    public function getProperty($propertyName)
+    {
+        return null;
+    }
+
+    public function hasProperty($propertyName): bool
+    {
+        return false;
+    }
+
+    public function getLabel(): string
+    {
+        return '';
+    }
+
+    public function setName($newName)
+    {
+    }
+
+    public function getName()
+    {
+    }
+
+    public function setProperty($propertyName, $value)
+    {
+    }
+
+    public function removeProperty($propertyName)
+    {
+    }
+
+    public function getPropertyNames()
+    {
+    }
+
+    public function setContentObject($contentObject)
+    {
+    }
+
+    public function getContentObject()
+    {
+    }
+
+    public function unsetContentObject()
+    {
+    }
+
+    public function setNodeType(NodeType $nodeType)
+    {
+    }
+
+    public function setHidden($hidden)
+    {
+    }
+
+    public function isHidden()
+    {
+    }
+
+    public function setHiddenBeforeDateTime(\DateTimeInterface $dateTime = null)
+    {
+    }
+
+    public function getHiddenBeforeDateTime()
+    {
+    }
+
+    public function setHiddenAfterDateTime(\DateTimeInterface $dateTime = null)
+    {
+    }
+
+    public function getHiddenAfterDateTime()
+    {
+    }
+
+    public function setHiddenInIndex($hidden)
+    {
+    }
+
+    public function isHiddenInIndex()
+    {
+    }
+
+    public function setAccessRoles(array $accessRoles)
+    {
+    }
+
+    public function getAccessRoles()
+    {
+    }
+
+    public function getPath()
+    {
+    }
+
+    public function getContextPath()
+    {
+    }
+
+    public function getDepth()
+    {
+    }
+
+    public function setWorkspace(Workspace $workspace)
+    {
+    }
+
+    public function getWorkspace()
+    {
+    }
+
+    public function getIdentifier()
+    {
+    }
+
+    public function setIndex($index)
+    {
+    }
+
+    public function getIndex()
+    {
+    }
+
+    public function getParent()
+    {
+    }
+
+    public function getParentPath()
+    {
+    }
+
+    public function createNode($name, NodeType $nodeType = null, $identifier = null)
+    {
+    }
+
+    public function createSingleNode($name, NodeType $nodeType = null, $identifier = null)
+    {
+    }
+
+    public function createNodeFromTemplate(NodeTemplate $nodeTemplate, $nodeName = null)
+    {
+    }
+
+    public function getNode($path)
+    {
+    }
+
+    public function getPrimaryChildNode()
+    {
+    }
+
+    public function getChildNodes($nodeTypeFilter = null, $limit = null, $offset = null)
+    {
+    }
+
+    public function hasChildNodes($nodeTypeFilter = null)
+    {
+    }
+
+    public function remove()
+    {
+    }
+
+    public function setRemoved($removed)
+    {
+    }
+
+    public function isRemoved()
+    {
+    }
+
+    public function isVisible()
+    {
+    }
+
+    public function isAccessible()
+    {
+    }
+
+    public function hasAccessRestrictions()
+    {
+    }
+
+    public function isNodeTypeAllowedAsChildNode(NodeType $nodeType)
+    {
+    }
+
+    public function moveBefore(NodeInterface $referenceNode)
+    {
+    }
+
+    public function moveAfter(NodeInterface $referenceNode)
+    {
+    }
+
+    public function moveInto(NodeInterface $referenceNode)
+    {
+    }
+
+    public function copyBefore(NodeInterface $referenceNode, $nodeName)
+    {
+    }
+
+    public function copyAfter(NodeInterface $referenceNode, $nodeName)
+    {
+    }
+
+    public function copyInto(NodeInterface $referenceNode, $nodeName)
+    {
+    }
+
+    public function getNodeData()
+    {
+    }
+
+    public function getContext()
+    {
+    }
+
+    public function getDimensions()
+    {
+    }
+
+    public function createVariantForContext($context)
+    {
+    }
+
+    public function isAutoCreated()
+    {
+    }
+
+    public function getOtherNodeVariants()
+    {
+    }
+}

--- a/Neos.EventSourcedContentRepository/Tests/Unit/Fixtures/ValidTraversableNode.php
+++ b/Neos.EventSourcedContentRepository/Tests/Unit/Fixtures/ValidTraversableNode.php
@@ -1,0 +1,160 @@
+<?php
+declare(strict_types=1);
+
+namespace Neos\EventSourcedContentRepository\Tests\Unit\Fixtures;
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\ContentRepository\DimensionSpace\DimensionSpace\DimensionSpacePoint;
+use Neos\ContentRepository\Domain\ContentStream\ContentStreamIdentifier;
+use Neos\ContentRepository\Domain\ContentSubgraph\NodePath;
+use Neos\ContentRepository\Domain\Model\ArrayPropertyCollection;
+use Neos\ContentRepository\Domain\Model\NodeType;
+use Neos\ContentRepository\Domain\NodeAggregate\NodeAggregateIdentifier;
+use Neos\ContentRepository\Domain\NodeAggregate\NodeName;
+use Neos\ContentRepository\Domain\NodeType\NodeTypeConstraints;
+use Neos\ContentRepository\Domain\NodeType\NodeTypeName;
+use Neos\ContentRepository\Domain\Projection\Content\PropertyCollectionInterface;
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodes;
+use Neos\EventSourcedContentRepository\Domain\Context\NodeAggregate\OriginDimensionSpacePoint;
+use Neos\EventSourcedContentRepository\Domain\ValueObject\PropertyName;
+use Neos\Flow\Annotations as Flow;
+use Neos\Neos\Controller\Exception\NodeNotFoundException;
+
+/**
+ * A valid traversable node implementation
+ */
+class ValidTraversableNode implements TraversableNodeInterface
+{
+    public function getCacheEntryIdentifier(): string
+    {
+        return '';
+    }
+
+    public function isRoot(): bool
+    {
+        return false;
+    }
+
+    public function isTethered(): bool
+    {
+        return false;
+    }
+
+    public function getContentStreamIdentifier(): ContentStreamIdentifier
+    {
+        return ContentStreamIdentifier::create();
+    }
+
+    public function getNodeAggregateIdentifier(): NodeAggregateIdentifier
+    {
+        return NodeAggregateIdentifier::create();
+    }
+
+    public function getNodeTypeName(): NodeTypeName
+    {
+        return NodeTypeName::fromString('Neos.ContentRepository:Test');
+    }
+
+    public function getNodeType(): NodeType
+    {
+        return new NodeType('Neos.ContentRepository:Test', [], []);
+    }
+
+    public function getNodeName(): ?NodeName
+    {
+        return null;
+    }
+
+    public function getOriginDimensionSpacePoint(): OriginDimensionSpacePoint
+    {
+        return OriginDimensionSpacePoint::fromArray([]);
+    }
+
+    public function getProperties(): PropertyCollectionInterface
+    {
+        return new ArrayPropertyCollection([]);
+    }
+
+    public function getProperty($propertyName)
+    {
+        return null;
+    }
+
+    public function hasProperty($propertyName): bool
+    {
+        return false;
+    }
+
+    public function getLabel(): string
+    {
+        return '';
+    }
+
+    public function getDimensionSpacePoint(): DimensionSpacePoint
+    {
+        return DimensionSpacePoint::fromArray([]);
+    }
+
+    public function findParentNode(): TraversableNodeInterface
+    {
+        throw new NodeNotFoundException();
+    }
+
+    public function findNodePath(): NodePath
+    {
+        return NodePath::fromString('/');
+    }
+
+    public function findNamedChildNode(NodeName $nodeName): TraversableNodeInterface
+    {
+        throw new NodeNotFoundException();
+    }
+
+    public function findChildNodes(
+        NodeTypeConstraints $nodeTypeConstraints = null,
+        int $limit = null,
+        int $offset = null
+    ): TraversableNodes {
+        return TraversableNodes::fromArray([]);
+    }
+
+    public function countChildNodes(NodeTypeConstraints $nodeTypeConstraints = null): int
+    {
+        return 0;
+    }
+
+    public function findReferencedNodes(): TraversableNodes
+    {
+        return TraversableNodes::fromArray([]);
+    }
+
+    public function findNamedReferencedNodes(PropertyName $edgeName): TraversableNodes
+    {
+        return TraversableNodes::fromArray([]);
+    }
+
+    public function findReferencingNodes(): TraversableNodes
+    {
+        return TraversableNodes::fromArray([]);
+    }
+
+    public function findNamedReferencingNodes(PropertyName $nodeName): TraversableNodes
+    {
+        return TraversableNodes::fromArray([]);
+    }
+
+    public function equals(TraversableNodeInterface $other): bool
+    {
+        return false;
+    }
+}

--- a/Neos.EventSourcedNeosAdjustments/Classes/Domain/Context/Content/NodeSiteResolvingService.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/Domain/Context/Content/NodeSiteResolvingService.php
@@ -25,7 +25,6 @@ use Neos\Flow\Annotations as Flow;
  */
 class NodeSiteResolvingService
 {
-
     /**
      * @Flow\Inject
      * @var WorkspaceFinder

--- a/Neos.EventSourcedNeosAdjustments/Classes/Eel/FlowQueryOperations/FindOperation.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/Eel/FlowQueryOperations/FindOperation.php
@@ -209,7 +209,7 @@ class FindOperation extends AbstractOperation
             $subgraph = $entryPoint['subgraph'];
             $nodeByIdentifier = $subgraph->findNodeByNodeAggregateIdentifier($nodeAggregateIdentifier);
             if ($nodeByIdentifier) {
-                $result[] = new TraversableNode($nodeByIdentifier, $subgraph);
+                $result[] = $nodeByIdentifier;
             }
         }
 
@@ -233,7 +233,7 @@ class FindOperation extends AbstractOperation
                     $nodeByPath = $subgraph->findNodeByPath($nodePath, $node->getNodeAggregateIdentifier());
                 }
                 if ($nodeByPath) {
-                    $result[] = new TraversableNode($nodeByPath, $subgraph);
+                    $result[] = $nodeByPath;
                 }
             }
         }

--- a/Neos.EventSourcedNeosAdjustments/Classes/Eel/FlowQueryOperations/FindOperation.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/Eel/FlowQueryOperations/FindOperation.php
@@ -250,9 +250,8 @@ class FindOperation extends AbstractOperation
                 return $node->getNodeAggregateIdentifier();
             }, $entryPoint['nodes']);
 
-            foreach ($subgraph->findDescendants($entryIdentifiers, $this->nodeTypeConstraintFactory->parseFilterString($nodeTypeName->jsonSerialize()), null) as $descendant) {
-                $result[] = new TraversableNode($descendant, $subgraph);
-            }
+            $descendants = $subgraph->findDescendants($entryIdentifiers, $this->nodeTypeConstraintFactory->parseFilterString($nodeTypeName->jsonSerialize()), null);
+            $result = array_merge($result, $descendants->toArray());
         }
 
         return $result;

--- a/Neos.EventSourcedNeosAdjustments/Classes/EventSourcedFrontController/EventSourcedNodeController.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/EventSourcedFrontController/EventSourcedNodeController.php
@@ -13,31 +13,29 @@ namespace Neos\EventSourcedNeosAdjustments\EventSourcedFrontController;
  */
 
 use Neos\ContentGraph\DoctrineDbalAdapter\Domain\Repository\NodeFactory;
-use Neos\ContentRepository\Domain\ContentSubgraph\NodePath;
 use Neos\ContentRepository\Domain\NodeType\NodeTypeConstraintFactory;
-use Neos\ContentRepository\Domain\Projection\Content\NodeInterface;
+use Neos\ContentRepository\Domain\ContentSubgraph\NodePath;
 use Neos\EventSourcedContentRepository\Domain\Context\ContentSubgraph\SubtreeInterface;
-use Neos\EventSourcedContentRepository\Domain\Context\NodeAddress\NodeAddress;
 use Neos\EventSourcedContentRepository\Domain\Context\Parameters\VisibilityConstraints;
 use Neos\EventSourcedContentRepository\Domain\Projection\Content\ContentGraphInterface;
 use Neos\EventSourcedContentRepository\Domain\Projection\Content\ContentSubgraphInterface;
 use Neos\EventSourcedContentRepository\Domain\Projection\Content\InMemoryCache;
+use Neos\ContentRepository\Domain\Projection\Content\NodeInterface;
 use Neos\EventSourcedContentRepository\Domain\Projection\Content\TraversableNode;
 use Neos\EventSourcedContentRepository\Domain\Projection\Workspace\WorkspaceFinder;
+use Neos\EventSourcedContentRepository\Domain\Context\NodeAddress\NodeAddress;
+use Neos\EventSourcedContentRepository\Domain\Context\NodeAddress\NodeAddressFactory;
 use Neos\EventSourcedNeosAdjustments\Domain\Context\Content\NodeSiteResolvingService;
 use Neos\EventSourcedNeosAdjustments\Domain\Service\NodeShortcutResolver;
-use Neos\EventSourcedNeosAdjustments\EventSourcedRouting\Exception\InvalidShortcutException;
-use Neos\EventSourcedNeosAdjustments\EventSourcedRouting\NodeUriBuilder;
 use Neos\EventSourcedNeosAdjustments\View\FusionView;
 use Neos\Flow\Annotations as Flow;
-
+use Neos\Flow\Http\Component\SetHeaderComponent;
 use Neos\Flow\Mvc\Controller\ActionController;
-use Neos\Flow\Mvc\Exception\NoMatchingRouteException;
 use Neos\Flow\Property\PropertyMapper;
-use Neos\Flow\Security\Context as SecurityContext;
 use Neos\Flow\Session\SessionInterface;
 use Neos\Flow\Utility\Now;
 use Neos\Neos\Controller\Exception\NodeNotFoundException;
+use Neos\Flow\Security\Context as SecurityContext;
 
 /**
  * Event Sourced Node Controller; as Replacement of NodeController
@@ -111,65 +109,15 @@ class EventSourcedNodeController extends ActionController
 
     /**
      * @Flow\Inject
+     * @var NodeAddressFactory
+     */
+    protected $nodeAddressService;
+
+    /**
+     * @Flow\Inject
      * @var NodeSiteResolvingService
      */
     protected $nodeSiteResolvingService;
-
-    /**
-     * @param NodeAddress $node Legacy name for backwards compatibility of route components
-     * @throws NodeNotFoundException
-     * @throws \Neos\Flow\Mvc\Exception\StopActionException
-     * @throws \Neos\Flow\Mvc\Exception\UnsupportedRequestTypeException
-     * @throws \Neos\Flow\Mvc\Routing\Exception\MissingActionNameException
-     * @throws \Neos\Flow\Session\Exception\SessionNotStartedException
-     * @throws \Neos\Neos\Exception
-     * @Flow\SkipCsrfProtection We need to skip CSRF protection here because this action could be called with unsafe requests from widgets or plugins that are rendered on the node - For those the CSRF token is validated on the sub-request, so it is safe to be skipped here
-     */
-    public function previewAction(NodeAddress $node)
-    {
-        $nodeAddress = $node;
-
-        $subgraph = $this->contentGraph->getSubgraphByIdentifier(
-            $nodeAddress->getContentStreamIdentifier(),
-            $nodeAddress->getDimensionSpacePoint(),
-            VisibilityConstraints::withoutRestrictions()
-        );
-        if ($subgraph === null) {
-            throw new NodeNotFoundException("TODO: SUBGRAPH NOT FOUND; should not happen (for address " . $nodeAddress);
-        }
-
-
-        $site = $this->nodeSiteResolvingService->findSiteNodeForNodeAddress($nodeAddress);
-        if ($site === null) {
-            throw new NodeNotFoundException("TODO: SITE NOT FOUND; should not happen (for address " . $nodeAddress);
-        }
-
-        $this->fillCacheWithContentNodes($subgraph, $nodeAddress);
-        $nodeInstance = $subgraph->findNodeByNodeAggregateIdentifier($nodeAddress->getNodeAggregateIdentifier());
-
-        if (is_null($nodeInstance)) {
-            throw new NodeNotFoundException('The requested node does not exist or isn\'t accessible to the current user', 1430218623);
-        }
-
-        $traversableNode = new TraversableNode($nodeInstance, $subgraph);
-        $traversableSite = new TraversableNode($site, $subgraph);
-
-        $this->view->assignMultiple([
-            'value' => $traversableNode,
-            'subgraph' => $subgraph,
-            'site' => $traversableSite,
-        ]);
-
-        $this->overrideViewVariablesFromInternalArguments();
-        $this->response->setHttpHeader('Cache-Control', 'no-cache');
-        if (!$this->view->canRenderWithNodeAndPath()) {
-            $this->view->setFusionPath('rawContent');
-        }
-
-        if ($this->session->isStarted()) {
-            $this->session->putData('lastVisitedNode', $nodeAddress);
-        }
-    }
 
     /**
      * Initializes the view with the necessary parameters encoded in the given NodeAddress
@@ -186,43 +134,63 @@ class EventSourcedNodeController extends ActionController
     public function showAction(NodeAddress $node)
     {
         $nodeAddress = $node;
-        if (!$nodeAddress->isInLiveWorkspace()) {
-            throw new NodeNotFoundException('The requested node isn\'t accessible to the current user', 1430218623);
-        }
+
+        $inBackend = !$nodeAddress->isInLiveWorkspace();
+        $visibilityConstraints = $this->createVisibilityConstraints($inBackend);
 
         $subgraph = $this->contentGraph->getSubgraphByIdentifier(
             $nodeAddress->getContentStreamIdentifier(),
             $nodeAddress->getDimensionSpacePoint(),
-            VisibilityConstraints::frontend()
+            $visibilityConstraints
         );
-        if ($subgraph === null) {
-            throw new NodeNotFoundException("TODO: SUBGRAPH NOT FOUND; should not happen (for address " . $nodeAddress);
-        }
 
         $site = $this->nodeSiteResolvingService->findSiteNodeForNodeAddress($nodeAddress);
-        if ($site === null) {
+        if (!$site) {
             throw new NodeNotFoundException("TODO: SITE NOT FOUND; should not happen (for address " . $nodeAddress);
         }
 
         $this->fillCacheWithContentNodes($subgraph, $nodeAddress);
-        $nodeInstance = $subgraph->findNodeByNodeAggregateIdentifier($nodeAddress->getNodeAggregateIdentifier());
+        $node = $subgraph->findNodeByNodeAggregateIdentifier($nodeAddress->getNodeAggregateIdentifier());
 
-        if (is_null($nodeInstance)) {
-            throw new NodeNotFoundException('The requested node does not exist', 1596191460);
+        if (is_null($node)) {
+            throw new NodeNotFoundException('The requested node does not exist or isn\'t accessible to the current user', 1430218623);
         }
 
-        if ($nodeInstance->getNodeType()->isOfType('Neos.Neos:Shortcut')) {
-            $this->handleShortcutNode($nodeAddress);
+        if ($node->getNodeType()->isOfType('Neos.Neos:Shortcut') && !$inBackend) {
+            $this->handleShortcutNode($subgraph, $node, $nodeAddress);
         }
-
-        $traversableNode = new TraversableNode($nodeInstance, $subgraph);
-        $traversableSite = new TraversableNode($site, $subgraph);
 
         $this->view->assignMultiple([
-            'value' => $traversableNode,
+            'value' => $node,
             'subgraph' => $subgraph,
-            'site' => $traversableSite,
+            'site' => $site,
         ]);
+
+        if ($inBackend) {
+            $this->overrideViewVariablesFromInternalArguments();
+            $this->response->setComponentParameter(SetHeaderComponent::class, 'Cache-Control', 'no-cache');
+            if (!$this->view->canRenderWithNodeAndPath()) {
+                $this->view->setFusionPath('rawContent');
+            }
+        }
+
+        if ($this->session->isStarted() && $inBackend) {
+            $this->session->putData('lastVisitedNode', $nodeAddress);
+        }
+    }
+
+
+    /**
+     * @param bool $inBackend
+     * @return VisibilityConstraints
+     */
+    protected function createVisibilityConstraints(bool $inBackend): VisibilityConstraints
+    {
+        if ($inBackend) {
+            return VisibilityConstraints::withoutRestrictions();
+        } else {
+            return VisibilityConstraints::frontend();
+        }
     }
 
     /**
@@ -245,7 +213,7 @@ class EventSourcedNodeController extends ActionController
         }
 
         if (($affectedNodeContextPath = $this->request->getInternalArgument('__affectedNodeContextPath')) !== null) {
-            $this->response->setHttpHeader('X-Neos-AffectedNodePath', $affectedNodeContextPath);
+            $this->response->setComponentParameter(SetHeaderComponent::class, 'X-Neos-AffectedNodePath', $affectedNodeContextPath);
         }
 
         if (($fusionPath = $this->request->getInternalArgument('__fusionPath')) !== null) {
@@ -256,31 +224,23 @@ class EventSourcedNodeController extends ActionController
     /**
      * Handles redirects to shortcut targets in live rendering.
      *
+     * @param ContentSubgraphInterface $subgraph
+     * @param NodeInterface $node
      * @param NodeAddress $nodeAddress
+     * @return void
      * @throws NodeNotFoundException
      * @throws \Neos\Flow\Mvc\Exception\StopActionException
      * @throws \Neos\Flow\Mvc\Exception\UnsupportedRequestTypeException
+     * @throws \Neos\Flow\Mvc\Routing\Exception\MissingActionNameException
      */
-    protected function handleShortcutNode(NodeAddress $nodeAddress): void
+    protected function handleShortcutNode(ContentSubgraphInterface $subgraph, NodeInterface $node, NodeAddress $nodeAddress): void
     {
-        try {
-            $resolvedTarget = $this->nodeShortcutResolver->resolveShortcutTarget($nodeAddress);
-        } catch (InvalidShortcutException $e) {
-            throw new NodeNotFoundException(sprintf('The shortcut node target of node "%s" could not be resolved: %s', $nodeAddress, $e->getMessage()), 1430218730, $e);
-        }
-        if ($resolvedTarget instanceof NodeAddress) {
-            if ($resolvedTarget === $nodeAddress) {
-                return;
-            }
-            try {
-                $resolvedUri = NodeUriBuilder::fromRequest($this->request)->uriFor($nodeAddress);
-            } catch (NoMatchingRouteException $e) {
-                throw new NodeNotFoundException(sprintf('The shortcut node target of node "%s" could not be resolved: %s', $nodeAddress, $e->getMessage()), 1599670695, $e);
-            }
+        $resolvedUri = $this->nodeShortcutResolver->resolveShortcutTarget($subgraph, $node, $nodeAddress, $this->uriBuilder, $this->request->getFormat());
+        if (!is_null($resolvedUri)) {
+            $this->redirectToUri($resolvedUri);
         } else {
-            $resolvedUri = $resolvedTarget;
+            throw new NodeNotFoundException(sprintf('The shortcut node target of node "%s" could not be resolved', $node->getNodeAggregateIdentifier()), 1430218730);
         }
-        $this->redirectToUri($resolvedUri);
     }
 
     private function fillCacheWithContentNodes(ContentSubgraphInterface $subgraph, NodeAddress $nodeAddress)

--- a/Neos.EventSourcedNeosAdjustments/Classes/EventSourcedRouting/EventSourcedFrontendNodeRoutePartHandler.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/EventSourcedRouting/EventSourcedFrontendNodeRoutePartHandler.php
@@ -12,65 +12,55 @@ namespace Neos\EventSourcedNeosAdjustments\EventSourcedRouting;
  * source code.
  */
 
+use Neos\ContentRepository\Domain\NodeType\NodeTypeConstraintFactory;
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
+use Neos\ContentRepository\Domain\Projection\Content\TraversableNodes;
+use Neos\EventSourcedContentRepository\Domain\Context\Parameters\VisibilityConstraints;
+use Neos\EventSourcedContentRepository\Domain\Projection\Content\ContentGraphInterface;
+use Neos\EventSourcedContentRepository\Domain\Projection\Content\ContentSubgraphInterface;
+use Neos\ContentRepository\Domain\Projection\Content\NodeInterface;
+use Neos\EventSourcedContentRepository\Domain\Projection\Content\NodeTreeTraversalHelper;
+use Neos\EventSourcedContentRepository\Domain\Projection\Workspace\WorkspaceFinder;
+use Neos\ContentRepository\Domain\Service\NodeTypeManager;
 use Neos\ContentRepository\DimensionSpace\DimensionSpace\DimensionSpacePoint;
 use Neos\ContentRepository\Domain\NodeAggregate\NodeName;
-use Neos\EventSourcedContentRepository\Domain\Context\NodeAddress\Exception\NodeAddressCannotBeSerializedException;
-use Neos\EventSourcedContentRepository\Domain\Context\NodeAddress\NodeAddress;
+use Neos\ContentRepository\Domain\NodeType\NodeTypeName;
 use Neos\EventSourcedContentRepository\Domain\ValueObject\WorkspaceName;
-use Neos\EventSourcedNeosAdjustments\Domain\Service\NodeShortcutResolver;
-use Neos\EventSourcedNeosAdjustments\EventSourcedRouting\Exception\InvalidShortcutException;
-use Neos\EventSourcedNeosAdjustments\EventSourcedRouting\Http\ContentDimensionLinking\Exception\InvalidContentDimensionValueUriProcessorException;
 use Neos\EventSourcedNeosAdjustments\EventSourcedRouting\Http\ContentSubgraphUriProcessor;
-use Neos\EventSourcedNeosAdjustments\EventSourcedRouting\Projection\DocumentUriPathFinder;
+use Neos\EventSourcedNeosAdjustments\EventSourcedRouting\Routing\WorkspaceNameAndDimensionSpacePointForUriSerialization;
 use Neos\Flow\Annotations as Flow;
-use Neos\Flow\Core\Bootstrap;
-use Neos\Flow\Mvc\Routing\AbstractRoutePart;
-use Neos\Flow\Mvc\Routing\Dto\MatchResult;
+use Neos\Flow\Log\ThrowableStorageInterface;
 use Neos\Flow\Mvc\Routing\Dto\ResolveResult;
-use Neos\Flow\Mvc\Routing\Dto\RouteParameters;
-use Neos\Flow\Mvc\Routing\Dto\UriConstraints;
-use Neos\Flow\Mvc\Routing\DynamicRoutePartInterface;
+use Neos\Flow\Mvc\Routing\Dto\RouteTags;
+use Neos\Flow\Mvc\Routing\DynamicRoutePart;
+use Neos\Flow\Mvc\Routing\Dto\MatchResult;
 use Neos\Flow\Mvc\Routing\ParameterAwareRoutePartInterface;
-use Neos\Neos\Controller\Exception\NodeNotFoundException;
-use Neos\Neos\Domain\Model\Domain;
-use Neos\Neos\Domain\Model\Site;
+use Neos\Flow\Security\Context;
+use Neos\EventSourcedContentRepository\Domain\Context\NodeAddress\NodeAddress;
+use Neos\EventSourcedContentRepository\Domain\Context\NodeAddress\NodeAddressFactory;
 use Neos\Neos\Domain\Repository\DomainRepository;
-use Neos\Neos\Domain\Repository\SiteRepository;
+use Neos\Neos\Routing\Exception\MissingNodePropertyException;
+use Neos\Neos\Routing\Exception\NoSiteException;
+use Neos\Neos\Routing\Exception\NoSuchNodeException;
+use Neos\Neos\Routing\Exception\NoWorkspaceException;
 use Neos\Neos\Routing\FrontendNodeRoutePartHandlerInterface;
-use Psr\Http\Message\UriInterface;
 
 /**
- * A route part handler for finding nodes in the website's frontend.
- * Uses a special projection {@see DocumentUriPathFinder}, and does NOT use the graph projection in any way.
- *
- * @Flow\Scope("singleton")
+ * A route part handler for finding nodes specifically in the website's frontend.
  */
-final class EventSourcedFrontendNodeRoutePartHandler extends AbstractRoutePart implements DynamicRoutePartInterface, ParameterAwareRoutePartInterface, FrontendNodeRoutePartHandlerInterface
+class EventSourcedFrontendNodeRoutePartHandler extends DynamicRoutePart implements FrontendNodeRoutePartHandlerInterface, ParameterAwareRoutePartInterface
 {
-    private string $splitString = '';
-
     /**
-     * @var NodeName[] (indexed by the corresponding host)
+     * @Flow\Inject
+     * @var ThrowableStorageInterface
      */
-    private array $siteNodeNameRuntimeCache = [];
+    protected $exceptionLogger;
 
     /**
      * @Flow\Inject
-     * @var DocumentUriPathFinder
+     * @var Context
      */
-    protected $documentUriPathFinder;
-
-    /**
-     * @Flow\Inject
-     * @var Bootstrap
-     */
-    protected $bootstrap;
-
-    /**
-     * @Flow\Inject
-     * @var SiteRepository
-     */
-    protected $siteRepository;
+    protected $securityContext;
 
     /**
      * @Flow\Inject
@@ -80,229 +70,382 @@ final class EventSourcedFrontendNodeRoutePartHandler extends AbstractRoutePart i
 
     /**
      * @Flow\Inject
+     * @var ContentGraphInterface
+     */
+    protected $contentGraph;
+
+    /**
+     * @Flow\Inject
+     * @var WorkspaceFinder
+     */
+    protected $workspaceFinder;
+
+    /**
+     * @Flow\Inject
+     * @var NodeAddressFactory
+     */
+    protected $nodeAddressFactory;
+
+    /**
+     * @Flow\Inject
      * @var ContentSubgraphUriProcessor
      */
     protected $contentSubgraphUriProcessor;
 
     /**
      * @Flow\Inject
-     * @var NodeShortcutResolver
+     * @var NodeTypeManager
      */
-    protected $nodeShortcutResolver;
+    protected $nodeTypeManager;
 
     /**
-     * @param mixed $requestPath
-     * @param RouteParameters $parameters
-     * @return bool|MatchResult
-     * @throws NodeAddressCannotBeSerializedException
+     * @Flow\Inject
+     * @var NodeTypeConstraintFactory
      */
-    public function matchWithParameters(&$requestPath, RouteParameters $parameters)
-    {
-        if (!is_string($requestPath)) {
-            return false;
-        }
-        if (!$parameters->has('dimensionSpacePoint') || !$parameters->has('requestUriHost')) {
-            return false;
-        }
-
-        $uriPathSegmentOffset = $parameters->getValue('uriPathSegmentOffset') ?? 0;
-        $remainingRequestPath = $this->truncateRequestPathAndReturnRemainder($requestPath, $uriPathSegmentOffset);
-        /** @var DimensionSpacePoint $dimensionSpacePoint */
-        $dimensionSpacePoint = $parameters->getValue('dimensionSpacePoint');
-
-        try {
-            $matchResult = $this->matchUriPath($requestPath, $dimensionSpacePoint, $parameters->getValue('requestUriHost'));
-        } catch (NodeNotFoundException $exception) {
-            // we silently swallow the Node Not Found case, as you'll see this in the server log if it interests you
-            // (and other routes could still handle this).
-            return false;
-        }
-        $requestPath = $remainingRequestPath;
-        return $matchResult;
-    }
+    protected $nodeTypeConstraintFactory;
 
     /**
-     * @param array $routeValues
-     * @param RouteParameters $parameters
-     * @return ResolveResult|bool
-     * @throws InvalidContentDimensionValueUriProcessorException
+     * Extracts the node path from the request path.
+     *
+     * @param string $requestPath The request path to be matched
+     * @return string value to match, or an empty string if $requestPath is empty or split string was not found
      */
-    public function resolveWithParameters(array &$routeValues, RouteParameters $parameters)
+    protected function findValueToMatch($requestPath)
     {
-        if ($this->name === null || $this->name === '' || !\array_key_exists($this->name, $routeValues)) {
-            return false;
-        }
-        if (!$parameters->has('requestUriHost')) {
-            return false;
-        }
-
-        $nodeAddress = $routeValues[$this->name];
-        if (!$nodeAddress instanceof NodeAddress) {
-            return false;
-        }
-
-        try {
-            $resolveResult = $this->resolveNodeAddress($nodeAddress, $parameters->getValue('requestUriHost'));
-        } catch (NodeNotFoundException | InvalidShortcutException $exception) {
-            // TODO log exception
-            return false;
-        }
-
-        unset($routeValues[$this->name]);
-        return $resolveResult;
-    }
-
-    /**
-     * @param NodeAddress $nodeAddress
-     * @param string $host
-     * @return ResolveResult
-     * @throws Http\ContentDimensionLinking\Exception\InvalidContentDimensionValueUriProcessorException
-     * @throws NodeNotFoundException | InvalidShortcutException
-     */
-    private function resolveNodeAddress(NodeAddress $nodeAddress, string $host): ResolveResult
-    {
-        $nodeInfo = $this->documentUriPathFinder->getByIdAndDimensionSpacePointHash($nodeAddress->getNodeAggregateIdentifier(), $nodeAddress->getDimensionSpacePoint()->getHash());
-        if ($nodeInfo->isDisabled()) {
-            throw new NodeNotFoundException(sprintf('The resolved node for address %s is disabled', $nodeAddress), 1599668357);
-        }
-        if ($nodeInfo->isShortcut()) {
-            $nodeInfo = $this->nodeShortcutResolver->resolveNode($nodeInfo);
-            if ($nodeInfo instanceof UriInterface) {
-                return $this->buildResolveResultFromUri($nodeInfo);
-            }
-            $nodeAddress = $nodeAddress->withNodeAggregateIdentifier($nodeInfo->getNodeAggregateIdentifier());
-        }
-        $uriConstraints = $this->contentSubgraphUriProcessor->resolveDimensionUriConstraints($nodeAddress);
-
-        if ((string)$nodeInfo->getSiteNodeName() !== (string)$this->getCurrentSiteNodeName($host)) {
-            /** @var Site $site */
-            foreach ($this->siteRepository->findOnline() as $site) {
-                if ($site->getNodeName() === (string)$nodeInfo->getSiteNodeName()) {
-                    $uriConstraints = $this->applyDomainToUriConstraints($uriConstraints, $site->getPrimaryDomain());
-                    break;
-                }
+        if ($this->splitString !== '') {
+            $splitStringPosition = strpos($requestPath, $this->splitString);
+            if ($splitStringPosition !== false) {
+                return substr($requestPath, 0, $splitStringPosition);
             }
         }
 
-        if (!empty($this->options['uriSuffix']) && $nodeInfo->hasUriPath()) {
-            $uriConstraints = $uriConstraints->withPathSuffix($this->options['uriSuffix']);
-        }
-        return new ResolveResult($nodeInfo->getUriPath(), $uriConstraints, $nodeInfo->getRouteTags());
+        return $requestPath;
     }
 
-
     /**
-     * @param string $uriPath
-     * @param DimensionSpacePoint $dimensionSpacePoint
-     * @param string $host
-     * @return MatchResult
-     * @throws NodeNotFoundException | NodeAddressCannotBeSerializedException
+     * Matches a frontend URI pointing to a node (for example a page).
+     *
+     * This function tries to find a matching node by the given request path. If one was found, its
+     * absolute context node path is set in $this->value and true is returned.
+     *
+     * Note that this matcher does not check if access to the resolved workspace or node is allowed because at the point
+     * in time the route part handler is invoked, the security framework is not yet fully initialized.
+     *
+     * @param string $requestPath The request path (without leading "/", relative to the current Site Node)
+     * @return bool|MatchResult An instance of MatchResult if value could be matched successfully, otherwise false.
+     * @throws \Exception
+     * @throws Exception\NoHomepageException if no node could be found on the homepage (empty $requestPath)
      */
-    private function matchUriPath(string $uriPath, DimensionSpacePoint $dimensionSpacePoint, string $host): MatchResult
+    protected function matchValue($requestPath)
     {
-        $nodeInfo = $this->documentUriPathFinder->getEnabledBySiteNodeNameUriPathAndDimensionSpacePointHash($this->getCurrentSiteNodeName($host), $uriPath, $dimensionSpacePoint->getHash());
+        if ($this->onlyMatchSiteNodes() && \mb_substr_count($requestPath, '/') > $this->getUriPathSegmentOffset()) {
+            return false;
+        }
+        /** @var NodeInterface $matchingRootNode */
+        $matchingRootNode = null;
+        /** @var NodeInterface $matchingNode */
+        $matchingNode = null;
+        /** @var NodeInterface $matchingSite */
+        $matchingSite = null;
+        /** @var ContentSubgraphInterface $matchingSubgraph */
+        $matchingSubgraph = null;
+        $tagArray = [];
+
+        $this->securityContext->withoutAuthorizationChecks(function () use (&$matchingRootNode, &$matchingNode, &$matchingSite, &$matchingSubgraph, $requestPath, &$tagArray) {
+            // fetch subgraph explicitly without authorization checks because the security context isn't available yet
+            // anyway and any Entity Privilege targeted on Workspace would fail at this point:
+            $matchingSubgraph = $this->fetchSubgraphForParameters($requestPath);
+            $sitesNodeAggregate = $this->contentGraph->findRootNodeAggregateByType($matchingSubgraph->getContentStreamIdentifier(), NodeTypeName::fromString('Neos.Neos:Sites'));
+            $matchingRootNode = $matchingSubgraph->findNodeByNodeAggregateIdentifier($sitesNodeAggregate->getIdentifier());
+            if (!$matchingRootNode) {
+                return;
+            }
+
+            $matchingSite = $this->fetchSiteFromRequest($matchingRootNode, $matchingSubgraph, $requestPath);
+            $tagArray[] = (string)$matchingSite->getNodeAggregateIdentifier();
+
+            if ($requestPath === '' || substr($requestPath, 0, 1) === '@') {
+                // if the request path is:
+                // - "" (empty string): we are at the homepage in the live WS
+                // - "@...": we are at the homepage in a user workspace
+                $matchingNode = $matchingSite;
+                return;
+            }
+
+            $matchingNode = $this->fetchNodeForRequestPath($matchingSubgraph, $matchingSite, $requestPath, $tagArray);
+        });
+        if (!$matchingNode) {
+            return false;
+        }
+        if ($this->onlyMatchSiteNodes()) {
+            // if we only want to match Site nodes, we need to go one level up and need to find the "Neos.Neos:Sites" node.
+            // Note this operation is usually fast because it is served from the ContentSubgraph's in-memory Cache
+            $parentOfMatchingNode = $matchingSubgraph->findParentNode($matchingNode->getNodeAggregateIdentifier());
+            $parentOfMatchingNodeIsSitesNode = $parentOfMatchingNode !== null && $parentOfMatchingNode->getNodeType()->isOfType('Neos.Neos:Sites');
+            if (!$parentOfMatchingNodeIsSitesNode) {
+                return false;
+            }
+        }
+
         $nodeAddress = new NodeAddress(
-            $this->documentUriPathFinder->getLiveContentStreamIdentifier(),
-            $dimensionSpacePoint,
-            $nodeInfo->getNodeAggregateIdentifier(),
-            WorkspaceName::forLive()
+            $matchingSubgraph->getContentStreamIdentifier(),
+            $matchingSubgraph->getDimensionSpacePoint(),
+            $matchingNode->getNodeAggregateIdentifier(),
+            $this->workspaceFinder->findOneByCurrentContentStreamIdentifier($matchingSubgraph->getContentStreamIdentifier())->getWorkspaceName()
         );
-        return new MatchResult($nodeAddress->serializeForUri(), $nodeInfo->getRouteTags());
+
+        return new MatchResult($nodeAddress->serializeForUri(), RouteTags::createFromArray($tagArray));
     }
 
-    private function getCurrentSiteNodeName(string $host): NodeName
+    /**
+     * Fetches the node from the given subgraph matching the given request path segments via the traversed uriPathSegment properties.
+     * In the process, the tag array is populated with the traversed nodes' (the fetched node and its parents) identifiers.
+     *
+     * @param ContentSubgraphInterface $subgraph
+     * @param TraversableNodeInterface $site
+     * @param string $requestPath
+     * @param array $tagArray
+     * @return TraversableNodeInterface|null
+     */
+    protected function fetchNodeForRequestPath(ContentSubgraphInterface $subgraph, TraversableNodeInterface $site, string $requestPath, array &$tagArray): ?TraversableNodeInterface
     {
-        if (!isset($this->siteNodeNameRuntimeCache[$host])) {
-            $site = null;
-            if (!empty($host)) {
-                $activeDomain = $this->domainRepository->findOneByHost($host, true);
-                if ($activeDomain !== null) {
-                    $site = $activeDomain->getSite();
+        $remainingUriPathSegments = explode('/', $requestPath);
+        $remainingUriPathSegments = array_slice($remainingUriPathSegments, $this->getUriPathSegmentOffset());
+        $matchingNode = null;
+        $documentNodeTypeFilter = $this->nodeTypeConstraintFactory->parseFilterString('Neos.Neos:Document');
+
+        $currentNode = $site;
+        foreach ($remainingUriPathSegments as $currentPathSegment) {
+            $pivot = \mb_strpos($currentPathSegment, '@');
+            if ($pivot !== false) {
+                $currentPathSegment = \mb_substr($currentPathSegment, 0, $pivot);
+            }
+
+            $childNodes = $subgraph->findChildNodes($currentNode->getNodeAggregateIdentifier(), $documentNodeTypeFilter);
+            $currentNode = self::findChildNodeWithMatchingPathSegment($childNodes, $currentPathSegment);
+            if ($currentNode === null) {
+                return null;
+            }
+            $tagArray[] = (string)$currentNode->getNodeAggregateIdentifier();
+        }
+
+        return $currentNode;
+    }
+
+    protected static function findChildNodeWithMatchingPathSegment(TraversableNodes $childNodes, string $currentPathSegment): ?NodeInterface
+    {
+        foreach ($childNodes as $childNode) {
+            if ($childNode->getProperty('uriPathSegment') === $currentPathSegment) {
+                return $childNode;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @param string $requestPath
+     * @return ContentSubgraphInterface
+     * @throws NoWorkspaceException
+     */
+    protected function fetchSubgraphForParameters(string $requestPath): ContentSubgraphInterface
+    {
+        $workspace = $this->workspaceFinder->findOneByName($this->getWorkspaceNameFromParameters() ?: WorkspaceName::forLive());
+        if (!$workspace) {
+            throw new NoWorkspaceException(sprintf('No workspace found for request path "%s"', $requestPath), 1346949318);
+        }
+
+        // when we are in live workspace, we use the "frontend" visibility constraints,
+        // to ensure we re-use the same subgraph as the frontend rendering; and also re-use
+        // their in-memory runtime caches.
+        // This is safe because in live workspace, only "visible" nodes can be routed to.
+        $visibilityConstraints = $workspace->getWorkspaceName()->isLive() ? VisibilityConstraints::frontend() : VisibilityConstraints::withoutRestrictions();
+
+        return $this->contentGraph->getSubgraphByIdentifier(
+            $workspace->getCurrentContentStreamIdentifier(),
+            $this->getDimensionSpacePointFromParameters(),
+            $visibilityConstraints
+        );
+    }
+
+    /**
+     * @param TraversableNodeInterface $rootNode
+     * @param ContentSubgraphInterface $contentSubgraph
+     * @param string $requestPath
+     * @return TraversableNodeInterface
+     * @throws NoSiteException
+     */
+    protected function fetchSiteFromRequest(TraversableNodeInterface $rootNode, ContentSubgraphInterface $contentSubgraph, string $requestPath): TraversableNodeInterface
+    {
+        $domain = $this->domainRepository->findOneByActiveRequest();
+        if ($domain) {
+            $site = $contentSubgraph->findChildNodeConnectedThroughEdgeName(
+                $rootNode->getNodeAggregateIdentifier(),
+                NodeName::fromString($domain->getSite()->getNodeName())
+            );
+        } else {
+            $site = $contentSubgraph->findChildNodes($rootNode->getNodeAggregateIdentifier())->getFirst();
+        }
+
+        if (!$site) {
+            throw new NoSiteException(sprintf('No site found for request path "%s"', $requestPath), 1346949693);
+        }
+
+        return $site;
+    }
+
+    /**
+     * @return WorkspaceName
+     */
+    protected function getWorkspaceNameFromParameters(): ?WorkspaceName
+    {
+        return $this->parameters->getValue('workspaceName');
+    }
+
+    /**
+     * @return DimensionSpacePoint
+     */
+    protected function getDimensionSpacePointFromParameters(): DimensionSpacePoint
+    {
+        return $this->parameters->getValue('dimensionSpacePoint');
+    }
+
+    /**
+     * @return int
+     */
+    protected function getUriPathSegmentOffset(): ?int
+    {
+        return $this->parameters->getValue('uriPathSegmentOffset');
+    }
+
+    /**
+     * Checks, whether given value is a NodeAddress object and if so, sets $this->value to the respective route path.
+     *
+     * In order to render a suitable frontend URI, this function strips off the path to the site node and only keeps
+     * the actual node path relative to that site node. In practice this function would set $this->value as follows:
+     *
+     * absolute node path: /sites/neostypo3org/homepage/about
+     * $this->value:       homepage/about
+     *
+     * absolute node path: /sites/neostypo3org/homepage/about@user-admin
+     * $this->value:       homepage/about@user-admin
+     *
+     * @param $node
+     * @return boolean|ResolveResult if value could be resolved successfully, otherwise false.
+     * @throws \Exception
+     */
+    protected function resolveValue($node)
+    {
+        $nodeAddress = $node;
+        $nodeAddressIsCorrectType = $nodeAddress instanceof NodeAddress || is_string($nodeAddress);
+        if (!$nodeAddressIsCorrectType) {
+            return false;
+        }
+
+        if (is_string($nodeAddress)) {
+            try {
+                $nodeAddress = $this->nodeAddressFactory->createFromUriString($nodeAddress);
+            } catch (\Throwable $exception) {
+                $this->exceptionLogger->logThrowable($exception);
+
+                return false;
+            }
+        }
+        /** @var NodeAddress $nodeAddress */
+        // when we are in live workspace, we use the "frontend" visibility constraints,
+        // to ensure we re-use the same subgraph as the frontend rendering; and also re-use
+        // their in-memory runtime caches.
+        // This is safe because in live workspace, only "visible" nodes can be routed to.
+        $visibilityConstraints = $nodeAddress->isInLiveWorkspace() ? VisibilityConstraints::frontend() : VisibilityConstraints::withoutRestrictions();
+
+
+        $subgraph = $this->contentGraph->getSubgraphByIdentifier($nodeAddress->getContentStreamIdentifier(), $nodeAddress->getDimensionSpacePoint(), $visibilityConstraints);
+        $node = $subgraph->findNodeByNodeAggregateIdentifier($nodeAddress->getNodeAggregateIdentifier());
+
+        if ($node === null) {
+            return false;
+        }
+
+        if (!$node->getNodeType()->isOfType('Neos.Neos:Document')) {
+            return false;
+        }
+
+        $parentNode = $subgraph->findParentNode($node->getNodeAggregateIdentifier());
+        // a node is a site node if the node above it it Neos.Neos:Sites
+        $isSiteNode = $parentNode && $parentNode->getNodeType()->isOfType('Neos.Neos:Sites');
+        if ($this->onlyMatchSiteNodes() && !$isSiteNode) {
+            return false;
+        }
+
+        $routePath = $isSiteNode ? '' : $this->getRequestPathByNode($subgraph, $node);
+
+        if (!$nodeAddress->isInLiveWorkspace()) {
+            $workspace = $this->workspaceFinder->findOneByCurrentContentStreamIdentifier($nodeAddress->getContentStreamIdentifier());
+            if ($workspace) {
+                $routePath .= WorkspaceNameAndDimensionSpacePointForUriSerialization::fromWorkspaceAndDimensionSpacePoint($workspace->getWorkspaceName(), $subgraph->getDimensionSpacePoint())->toBackendUriSuffix();
+            } else {
+                throw new \Exception("TODO: Workspace not found for CS " . $nodeAddress->getContentStreamIdentifier());
+            }
+        }
+        $uriConstraints = $this->contentSubgraphUriProcessor->resolveDimensionUriConstraints($nodeAddress, $isSiteNode);
+
+        return new ResolveResult($routePath, $uriConstraints);
+    }
+
+    /**
+     * Whether the current route part should only match/resolve site nodes (e.g. the homepage)
+     *
+     * @return boolean
+     */
+    protected function onlyMatchSiteNodes(): bool
+    {
+        return $this->options['onlyMatchSiteNodes'] ?? false;
+    }
+
+    /**
+     * Renders a request path based on the "uriPathSegment" properties of the nodes leading to the given node.
+     *
+     * @param ContentSubgraphInterface $contentSubgraph
+     * @param NodeInterface $node The node where the generated path should lead to
+     * @return string A relative request path
+     * @throws \Exception
+     */
+    protected function getRequestPathByNode(ContentSubgraphInterface $contentSubgraph, NodeInterface $node)
+    {
+        // if the parent is the "sites" node, we return the empty URL.
+        $parentNode = $contentSubgraph->findParentNode($node->getNodeAggregateIdentifier());
+        if ($parentNode->getNodeType()->isOfType('Neos.Neos:Sites')) {
+            return '';
+        }
+
+        // To allow building of paths to non-hidden nodes beneath hidden nodes, we assume
+        // the input node is allowed to be seen and we must generate the full path here.
+        // To disallow showing a node actually hidden itself has to be ensured in matching
+        // a request path, not in building one.
+        $requestPathSegments = [];
+        $this->securityContext->withoutAuthorizationChecks(function () use ($contentSubgraph, $node, &$requestPathSegments) {
+            NodeTreeTraversalHelper::traverseUpUntilCondition(
+                $contentSubgraph,
+                $node,
+                function (NodeInterface $node) use (&$requestPathSegments, $contentSubgraph) {
+                    if (!$node->hasProperty('uriPathSegment')) {
+                        throw new MissingNodePropertyException(sprintf(
+                            'Missing "uriPathSegment" property for node "%s". Nodes can be migrated with the "flow node:repair" command.',
+                            $node->getNodeAggregateIdentifier()
+                        ), 1415020326);
+                    }
+
+                    $parentNode = $contentSubgraph->findParentNode($node->getNodeAggregateIdentifier());
+                    if ($parentNode->getNodeType()->isOfType('Neos.Neos:Sites')) {
+                        // do not traverse further up than the Site node (which is one level beneath the "Sites" node.
+                        return false;
+                    }
+
+                    $requestPathSegments[] = $node->getProperty('uriPathSegment');
+                    return true;
                 }
-            }
-            if ($site === null) {
-                $site = $this->siteRepository->findFirstOnline();
-            }
-            $this->siteNodeNameRuntimeCache[$host] = NodeName::fromString($site->getNodeName());
-        }
-        return $this->siteNodeNameRuntimeCache[$host];
-    }
+            );
+        });
 
-    private function truncateRequestPathAndReturnRemainder(string &$requestPath, int $uriPathSegmentOffset): string
-    {
-        $uriPathSegments = array_slice(explode('/', $requestPath), $uriPathSegmentOffset);
-        $requestPath = implode('/', $uriPathSegments);
-        if (!empty($this->options['uriSuffix'])) {
-            $suffixPosition = strpos($requestPath, $this->options['uriSuffix']);
-            if ($suffixPosition === false) {
-                return '';
-            }
-            $requestPath = substr($requestPath, 0, $suffixPosition);
-        }
-        if ($this->splitString === '' || $this->splitString === '/') {
-            return '';
-        }
-        $splitStringPosition = strpos($requestPath, $this->splitString);
-        if ($splitStringPosition === false) {
-            return '';
-        }
-        $fullRequestPath = $requestPath;
-        $requestPath = substr($requestPath, 0, $splitStringPosition);
-
-        return substr($fullRequestPath, $splitStringPosition);
-    }
-
-
-    private function buildResolveResultFromUri(UriInterface $uri): ResolveResult
-    {
-        $uriConstraints = UriConstraints::create();
-        if (!empty($uri->getScheme())) {
-            $uriConstraints = $uriConstraints->withScheme($uri->getScheme());
-        }
-        if (!empty($uri->getHost())) {
-            $uriConstraints = $uriConstraints->withHost($uri->getHost());
-        }
-        if ($uri->getPort() !== null) {
-            $uriConstraints = $uriConstraints->withPort($uri->getPort());
-        } elseif (!empty($uri->getScheme())) {
-            $uriConstraints = $uriConstraints->withPort($uri->getScheme() === 'https' ? 443 : 80);
-        }
-        if (!empty($uri->getQuery())) {
-            $uriConstraints = $uriConstraints->withQueryString($uri->getQuery());
-        }
-        if (!empty($uri->getFragment())) {
-            $uriConstraints = $uriConstraints->withFragment($uri->getFragment());
-        }
-        return new ResolveResult($uri->getPath(), $uriConstraints);
-    }
-
-    private function applyDomainToUriConstraints(UriConstraints $uriConstraints, ?Domain $domain): UriConstraints
-    {
-        if ($domain === null) {
-            return $uriConstraints;
-        }
-        $uriConstraints = $uriConstraints->withHost($domain->getHostname());
-        if (!empty($domain->getScheme())) {
-            $uriConstraints = $uriConstraints->withScheme($domain->getScheme());
-        }
-        if (!empty($domain->getPort())) {
-            $uriConstraints = $uriConstraints->withPort($domain->getPort());
-        }
-        return $uriConstraints;
-    }
-
-    public function setSplitString($splitString): void
-    {
-        $this->splitString = $splitString;
-    }
-
-    public function match(&$routePath)
-    {
-        throw new \BadMethodCallException('match() is not supported by this Route Part Handler, use "matchWithParameters" instead', 1568287772);
-    }
-
-    public function resolve(array &$routeValues)
-    {
-        throw new \BadMethodCallException('resolve() is not supported by this Route Part Handler, use "resolveWithParameters" instead', 1611600169);
+        return implode('/', array_reverse($requestPathSegments));
     }
 }

--- a/Neos.EventSourcedNeosAdjustments/Classes/Fusion/DimensionsMenuItemsImplementation.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/Fusion/DimensionsMenuItemsImplementation.php
@@ -105,7 +105,7 @@ class DimensionsMenuItemsImplementation extends AbstractMenuItemsImplementation
                 if ($variant === null || !$this->isNodeHidden($variant)) {
                     $menuItems[] = [
                         'subgraph' => $subgraph,
-                        'node' => $variant ? new TraversableNode($variant, $subgraph) : null,
+                        'node' => $variant,
                         'state' => $this->calculateItemState($variant),
                         'label' => $this->determineLabel($variant, $metadata),
                         'targetDimensions' => $metadata

--- a/Neos.EventSourcedNeosAdjustments/Classes/ServiceControllers/ServiceNodesController.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/ServiceControllers/ServiceNodesController.php
@@ -95,7 +95,7 @@ class ServiceNodesController extends ActionController
      * @param string $workspaceName Name of the workspace to search in, "live" by default
      * @param array $dimensions Optional list of dimensions and their values which should be used for querying
      * @param array $nodeTypes A list of node types the list should be filtered by
-     * @param NodeAddress $contextNode a node to use as context for the search
+     * @param NodeAddress|null $contextNode a node to use as context for the search
      * @return string
      */
     public function indexAction($searchTerm = '', array $nodeIdentifiers = [], $workspaceName = 'live', array $dimensions = [], array $nodeTypes = ['Neos.Neos:Document'], NodeAddress $contextNode = null)
@@ -111,15 +111,11 @@ class ServiceNodesController extends ActionController
         $traversableNodes = [];
 
         if ($nodeIdentifiers === []) {
-            $nodes = $subgraph->findDescendants(
+            $traversableNodes = $subgraph->findDescendants(
                 [$nodeAddress->getNodeAggregateIdentifier()],
                 $this->nodeTypeConstraintFactory->parseFilterString(implode(',', $nodeTypes)),
                 SearchTerm::fulltext($searchTerm)
-            );
-
-            foreach ($nodes as $node) {
-                $traversableNodes[] = new TraversableNode($node, $subgraph);
-            }
+            )->toArray();
         } else {
             if (!empty($searchTerm)) {
                 throw new \RuntimeException('Combination of $nodeIdentifiers and $searchTerm not supported');
@@ -128,7 +124,7 @@ class ServiceNodesController extends ActionController
             foreach ($nodeIdentifiers as $nodeAggregateIdentifier) {
                 $node = $subgraph->findNodeByNodeAggregateIdentifier(NodeAggregateIdentifier::fromString($nodeAggregateIdentifier));
                 if ($node !== null) {
-                    $traversableNodes[] = new TraversableNode($node, $subgraph);
+                    $traversableNodes[] = $node;
                 }
             }
         }

--- a/Neos.EventSourcedNeosAdjustments/Classes/Ui/ContentRepository/Service/NodeService.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/Ui/ContentRepository/Service/NodeService.php
@@ -15,9 +15,9 @@ namespace Neos\EventSourcedNeosAdjustments\Ui\ContentRepository\Service;
 use Neos\ContentRepository\Domain\Projection\Content\TraversableNodeInterface;
 use Neos\Eel\FlowQuery\FlowQuery;
 use Neos\Error\Messages\Error;
+use Neos\EventSourcedContentRepository\Domain\Context\NodeAddress\NodeAddressFactory;
 use Neos\EventSourcedContentRepository\Domain\Context\Parameters\VisibilityConstraints;
 use Neos\EventSourcedContentRepository\Domain\Projection\Content\ContentGraphInterface;
-use Neos\EventSourcedContentRepository\Domain\Projection\Content\TraversableNode;
 use Neos\Flow\Annotations as Flow;
 
 /**
@@ -27,15 +27,15 @@ class NodeService
 {
     /**
      * @Flow\Inject
-     * @var \Neos\EventSourcedContentRepository\Domain\Context\NodeAddress\NodeAddressFactory
+     * @var NodeAddressFactory
      */
-    protected $nodeAddressFactory;
+    protected NodeAddressFactory $nodeAddressFactory;
 
     /**
      * @Flow\Inject
      * @var ContentGraphInterface
      */
-    protected $contentGraph;
+    protected ContentGraphInterface $contentGraph;
 
     /**
      * Helper method to retrieve the closest document for a node
@@ -69,14 +69,14 @@ class NodeService
      * Converts a given context path to a node object
      *
      * @param string $contextPath
-     * @return TraversableNode|Error
+     * @return TraversableNodeInterface|Error
      */
     public function getNodeFromContextPath($contextPath)
     {
         $nodeAddress = $this->nodeAddressFactory->createFromUriString($contextPath);
         $subgraph = $this->contentGraph
             ->getSubgraphByIdentifier($nodeAddress->getContentStreamIdentifier(), $nodeAddress->getDimensionSpacePoint(), VisibilityConstraints::withoutRestrictions());
-        $node = $subgraph->findNodeByNodeAggregateIdentifier($nodeAddress->getNodeAggregateIdentifier());
-        return new TraversableNode($node, $subgraph);
+
+        return $subgraph->findNodeByNodeAggregateIdentifier($nodeAddress->getNodeAggregateIdentifier());
     }
 }

--- a/Neos.EventSourcedNeosAdjustments/Classes/Ui/Controller/BackendController.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/Ui/Controller/BackendController.php
@@ -20,7 +20,6 @@ use Neos\ContentRepository\Domain\NodeAggregate\NodeName;
 use Neos\ContentRepository\Domain\NodeType\NodeTypeName;
 use Neos\EventSourcedContentRepository\Domain\Context\Parameters\VisibilityConstraints;
 use Neos\EventSourcedContentRepository\Domain\Projection\Content\ContentGraphInterface;
-use Neos\EventSourcedContentRepository\Domain\Projection\Content\TraversableNode;
 use Neos\EventSourcedContentRepository\Domain\Projection\Workspace\WorkspaceFinder;
 use Neos\EventSourcedContentRepository\Domain\ValueObject\WorkspaceName;
 use Neos\EventSourcedContentRepository\Domain\Context\NodeAddress\NodeAddress;
@@ -44,7 +43,6 @@ use Neos\Neos\Ui\Domain\Service\StyleAndJavascriptInclusionService;
 
 class BackendController extends ActionController
 {
-
     /**
      * @var string
      */
@@ -78,12 +76,6 @@ class BackendController extends ActionController
      * @var SiteRepository
      */
     protected $siteRepository;
-
-    /**
-     * @Flow\Inject
-     * @var PersistenceManagerInterface
-     */
-    protected $persistenceManager;
 
     /**
      * @Flow\Inject
@@ -153,7 +145,7 @@ class BackendController extends ActionController
     /**
      * Displays the backend interface
      *
-     * @param \Neos\EventSourcedContentRepository\Domain\Context\NodeAddress\NodeAddress $node The node that will be displayed on the first tab
+     * @param NodeAddress|null $node The node that will be displayed on the first tab
      * @return void
      */
     public function indexAction(NodeAddress $node = null)
@@ -171,15 +163,16 @@ class BackendController extends ActionController
         $workspaceName = $this->userService->getPersonalWorkspaceName();
         $workspace = $this->workspaceFinder->findOneByName(new WorkspaceName($workspaceName));
         $subgraph = $this->contentGraph->getSubgraphByIdentifier($workspace->getCurrentContentStreamIdentifier(), $this->findDefaultDimensionSpacePoint(), VisibilityConstraints::withoutRestrictions());
-        $siteNode = $subgraph->findChildNodeConnectedThroughEdgeName($this->getRootNodeAggregateIdentifier($workspace->getCurrentContentStreamIdentifier()), NodeName::fromString($this->siteRepository->findDefault()->getNodeName()));
-        $siteNode = new TraversableNode($siteNode, $subgraph);
+        $siteNode = $subgraph->findChildNodeConnectedThroughEdgeName(
+            $this->getRootNodeAggregateIdentifier($workspace->getCurrentContentStreamIdentifier()),
+            NodeName::fromString($this->siteRepository->findDefault()->getNodeName())
+        );
 
         if (!$nodeAddress) {
             // TODO: fix resolving node address from session?
             $node = $siteNode;
         } else {
             $node = $subgraph->findNodeByNodeAggregateIdentifier($nodeAddress->getNodeAggregateIdentifier());
-            $node = new TraversableNode($node, $subgraph);
         }
 
         $this->view->assign('user', $user);
@@ -200,7 +193,7 @@ class BackendController extends ActionController
     }
 
     /**
-     * @param \Neos\EventSourcedContentRepository\Domain\Context\NodeAddress\NodeAddress $node
+     * @param NodeAddress $node
      * @throws \Neos\Flow\Mvc\Exception\StopActionException
      */
     public function redirectToAction(NodeAddress $node)

--- a/Neos.EventSourcedNeosAdjustments/Classes/Ui/Domain/Model/Changes/Property.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/Ui/Domain/Model/Changes/Property.php
@@ -306,7 +306,6 @@ class Property extends AbstractChange
             // Thus, we need to re-fetch it (as a workaround; until we do not need this anymore)
             $subgraph = $this->contentGraph->getSubgraphByIdentifier($node->getContentStreamIdentifier(), $node->getDimensionSpacePoint(), VisibilityConstraints::withoutRestrictions());
             $node = $subgraph->findNodeByNodeAggregateIdentifier($node->getNodeAggregateIdentifier());
-            $node = new TraversableNode($node, $subgraph);
 
             $this->updateWorkspaceInfo();
 

--- a/Neos.EventSourcedNeosAdjustments/Classes/Ui/Service/PublishingService.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/Ui/Service/PublishingService.php
@@ -36,30 +36,35 @@ use Neos\ContentRepository\Domain\Model\Workspace;
  */
 class PublishingService
 {
-
     /**
      * @Flow\Inject
      * @var ContentDimensionPresetSourceInterface
      */
-    protected $contentDimensionPresetSource;
+    protected ContentDimensionPresetSourceInterface $contentDimensionPresetSource;
 
     /**
      * @Flow\Inject
      * @var ContentGraphInterface
      */
-    protected $contentGraph;
+    protected ContentGraphInterface $contentGraph;
 
     /**
      * @Flow\Inject
      * @var WorkspaceFinder
      */
-    protected $workspaceFinder;
+    protected WorkspaceFinder $workspaceFinder;
 
     /**
      * @Flow\Inject
      * @var ChangeFinder
      */
-    protected $changeFinder;
+    protected ChangeFinder $changeFinder;
+
+    /**
+     * @Flow\Inject
+     * @var WorkspaceCommandHandler
+     */
+    protected WorkspaceCommandHandler $workspaceCommandHandler;
 
     /**
      * Returns a list of nodes contained in the given workspace which are not yet published
@@ -77,7 +82,6 @@ class PublishingService
         $changes = $this->changeFinder->findByContentStreamIdentifier($workspace->getCurrentContentStreamIdentifier());
         $unpublishedNodes = [];
         foreach ($changes as $change) {
-            /* @var $change Change */
             $subgraph = $this->contentGraph->getSubgraphByIdentifier(
                 $workspace->getCurrentContentStreamIdentifier(),
                 $change->originDimensionSpacePoint,
@@ -85,8 +89,8 @@ class PublishingService
             );
             $node = $subgraph->findNodeByNodeAggregateIdentifier($change->nodeAggregateIdentifier);
 
-            if ($node instanceof NodeInterface) {
-                $unpublishedNodes[] = new TraversableNode($node, $subgraph);
+            if ($node instanceof TraversableNodeInterface) {
+                $unpublishedNodes[] = new $node;
             }
         }
         return $unpublishedNodes;
@@ -104,13 +108,6 @@ class PublishingService
         $workspace = $this->workspaceFinder->findOneByName(new WorkspaceName($workspace->getName()));
         return $this->changeFinder->countByContentStreamIdentifier($workspace->getCurrentContentStreamIdentifier());
     }
-
-
-    /**
-     * @Flow\Inject
-     * @var WorkspaceCommandHandler
-     */
-    protected $workspaceCommandHandler;
 
     /**
      * @param WorkspaceName $workspaceName

--- a/Neos.EventSourcedNeosAdjustments/Classes/WorkspaceModule/Controller/WorkspacesController.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/WorkspaceModule/Controller/WorkspacesController.php
@@ -537,7 +537,6 @@ class WorkspacesController extends AbstractModuleController
             $subgraph = $this->contentGraph->getSubgraphByIdentifier($contentStreamIdentifier, $change->originDimensionSpacePoint, VisibilityConstraints::withoutRestrictions());
 
             $node = $subgraph->findNodeByNodeAggregateIdentifier($change->nodeAggregateIdentifier);
-            $node = new TraversableNode($node, $subgraph);
             $pathParts = explode('/', (string)$node->findNodePath());
             if (count($pathParts) > 2) {
                 $siteNodeName = $pathParts[2];
@@ -595,8 +594,8 @@ class WorkspacesController extends AbstractModuleController
     protected function getOriginalNode(TraversableNodeInterface $modifiedNode, ContentStreamIdentifier $baseContentStreamIdentifier): ?TraversableNodeInterface
     {
         $baseSubgraph = $this->contentGraph->getSubgraphByIdentifier($baseContentStreamIdentifier, $modifiedNode->getDimensionSpacePoint(), VisibilityConstraints::withoutRestrictions());
-        $node = $baseSubgraph->findNodeByNodeAggregateIdentifier($modifiedNode->getNodeAggregateIdentifier());
-        return $node ? new TraversableNode($node, $baseSubgraph) : null;
+
+        return $baseSubgraph->findNodeByNodeAggregateIdentifier($modifiedNode->getNodeAggregateIdentifier());
     }
 
     /**
@@ -604,10 +603,13 @@ class WorkspacesController extends AbstractModuleController
      * with meta information, in an array.
      *
      * @param TraversableNodeInterface $changedNode
+     * @param ContentStreamIdentifier $contentStreamIdentifierOfOriginalNode
      * @return array
      */
-    protected function renderContentChanges(TraversableNodeInterface $changedNode, ContentStreamIdentifier $contentStreamIdentifierOfOriginalNode)
-    {
+    protected function renderContentChanges(
+        TraversableNodeInterface $changedNode,
+        ContentStreamIdentifier $contentStreamIdentifierOfOriginalNode
+    ) {
         $currentWorkspace = $this->workspaceFinder->findOneByCurrentContentStreamIdentifier($contentStreamIdentifierOfOriginalNode);
         $originalNode = null;
         if ($currentWorkspace !== null) {
@@ -619,7 +621,7 @@ class WorkspacesController extends AbstractModuleController
 
         $contentChanges = [];
 
-        $changeNodePropertiesDefaults = $changedNode->getNodeType()->getDefaultValuesForProperties($changedNode);
+        $changeNodePropertiesDefaults = $changedNode->getNodeType()->getDefaultValuesForProperties();
 
         $renderer = new HtmlArrayRenderer();
         foreach ($changedNode->getProperties() as $propertyName => $changedPropertyValue) {

--- a/Neos.EventSourcedNeosAdjustments/Tests/Behavior/Features/Bootstrap/FlowQueryTrait.php
+++ b/Neos.EventSourcedNeosAdjustments/Tests/Behavior/Features/Bootstrap/FlowQueryTrait.php
@@ -60,10 +60,7 @@ trait FlowQueryTrait
             VisibilityConstraints::withoutRestrictions()
         );
         $nodeAggregateIdentifier = NodeAggregateIdentifier::fromString($serializedNodeAggregateIdentifier);
-        $node = new TraversableNode(
-            $subgraph->findNodeByNodeAggregateIdentifier($nodeAggregateIdentifier),
-            $subgraph
-        );
+        $node = $subgraph->findNodeByNodeAggregateIdentifier($nodeAggregateIdentifier);
         $this->currentFlowQuery = new FlowQuery([$node]);
     }
 


### PR DESCRIPTION
This will provide the capability for custom TraversableNodeInterface implementations via NodeType configuration in a similar way the old CR did it.

The main change is that there is now a central factory for creating TraversableNodes that is used internally by the ContentSubgraph, which now only communicates in TraversableNodeInterface.

There are a few occurrences of TraversableNode instantiation whose removal has yet to be discussed