### PR TITLE
BUGFIX: Fix PHP 8 compatibility

### DIFF
--- a/Neos.ContentGraph.DoctrineDbalAdapter/Classes/Domain/Projection/GraphProjector.php
+++ b/Neos.ContentGraph.DoctrineDbalAdapter/Classes/Domain/Projection/GraphProjector.php
@@ -65,12 +65,10 @@ class GraphProjector extends AbstractProcessedEventsAwareProjector
     public function reset(): void
     {
         parent::reset();
-        $this->getDatabaseConnection()->transactional(function () {
-            $this->getDatabaseConnection()->executeQuery('TRUNCATE table neos_contentgraph_node');
-            $this->getDatabaseConnection()->executeQuery('TRUNCATE table neos_contentgraph_hierarchyrelation');
-            $this->getDatabaseConnection()->executeQuery('TRUNCATE table neos_contentgraph_referencerelation');
-            $this->getDatabaseConnection()->executeQuery('TRUNCATE table neos_contentgraph_restrictionrelation');
-        });
+        $this->getDatabaseConnection()->executeQuery('TRUNCATE table neos_contentgraph_node');
+        $this->getDatabaseConnection()->executeQuery('TRUNCATE table neos_contentgraph_hierarchyrelation');
+        $this->getDatabaseConnection()->executeQuery('TRUNCATE table neos_contentgraph_referencerelation');
+        $this->getDatabaseConnection()->executeQuery('TRUNCATE table neos_contentgraph_restrictionrelation');
     }
 
     /**

--- a/Neos.EventSourcedContentRepository/Classes/Domain/Projection/Changes/ChangeProjector.php
+++ b/Neos.EventSourcedContentRepository/Classes/Domain/Projection/Changes/ChangeProjector.php
@@ -57,9 +57,7 @@ class ChangeProjector implements ProjectorInterface
 
     public function reset(): void
     {
-        $this->transactional(function () {
-            $this->getDatabaseConnection()->executeStatement('TRUNCATE table neos_contentrepository_projection_change');
-        });
+        $this->getDatabaseConnection()->executeStatement('TRUNCATE table neos_contentrepository_projection_change');
     }
 
 

--- a/Neos.EventSourcedContentRepository/Classes/Domain/Projection/NodeHiddenState/NodeHiddenStateProjector.php
+++ b/Neos.EventSourcedContentRepository/Classes/Domain/Projection/NodeHiddenState/NodeHiddenStateProjector.php
@@ -50,9 +50,7 @@ class NodeHiddenStateProjector implements ProjectorInterface
 
     public function reset(): void
     {
-        $this->transactional(function () {
-            $this->getDatabaseConnection()->executeStatement('TRUNCATE table neos_contentrepository_projection_nodehiddenstate');
-        });
+        $this->getDatabaseConnection()->executeStatement('TRUNCATE table neos_contentrepository_projection_nodehiddenstate');
     }
 
     public function whenNodeAggregateWasDisabled(NodeAggregateWasDisabled $event)


### PR DESCRIPTION
## Description

With PHP 8  replaying all projections with MySQL/MariaDB leads to a `PDOException`:
```
There is no active transaction
```

## Background

With PHP 8 (concretely since https://github.com/php/php-src/commit/990bb34) more errors  are reported and now surface.
In this case we were trying to commit an auto-commited transaction (see https://github.com/doctrine/migrations/issues/1202):
Structural changes to a MySQL db (including `TRUNCATE`) must not be done in a transaction.