### PR TITLE
Custom SearchOperation implementation

### DIFF
--- a/Neos.EventSourcedNeosAdjustments/Classes/Eel/FlowQueryOperations/SearchOperation.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/Eel/FlowQueryOperations/SearchOperation.php
@@ -41,13 +41,6 @@ class SearchOperation extends AbstractOperation
     protected static $priority = 110;
 
     /**
-     * {@inheritdoc}
-     *
-     * @var boolean
-     */
-    protected static $final = true;
-
-    /**
      * @Flow\Inject
      * @var NodeAccessorManager
      */
@@ -93,6 +86,6 @@ class SearchOperation extends AbstractOperation
             $this->nodeTypeConstraintFactory->parseFilterString($arguments[1] ?? ''),
             SearchTerm::fulltext($arguments[0] ?? '')
         );
-        $flowQuery->setContext($nodes);
+        $flowQuery->setContext(iterator_to_array($nodes));
     }
 }

--- a/Neos.EventSourcedNeosAdjustments/Classes/Eel/FlowQueryOperations/SearchOperation.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/Eel/FlowQueryOperations/SearchOperation.php
@@ -1,0 +1,98 @@
+<?php
+namespace Neos\EventSourcedNeosAdjustments\Eel\FlowQueryOperations;
+
+/*
+ * This file is part of the Neos.ContentRepository package.
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\ContentRepository\Domain\NodeType\NodeTypeConstraintFactory;
+use Neos\EventSourcedContentRepository\Domain\Projection\Content\SearchTerm;
+use Neos\Flow\Annotations as Flow;
+use Neos\Eel\FlowQuery\FlowQuery;
+use Neos\Eel\FlowQuery\Operations\AbstractOperation;
+use Neos\EventSourcedContentRepository\ContentAccess\NodeAccessorManager;
+use Neos\EventSourcedContentRepository\Domain\Projection\Content\NodeInterface;
+
+/**
+ * Custom search operation using the Content Graph fulltext search
+ *
+ * Original implementation: \Neos\Neos\Ui\FlowQueryOperations\SearchOperation
+ */
+class SearchOperation extends AbstractOperation
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @var string
+     */
+    protected static $shortName = 'search';
+
+    /**
+     * {@inheritdoc}
+     *
+     * @var integer
+     */
+    protected static $priority = 110;
+
+    /**
+     * {@inheritdoc}
+     *
+     * @var boolean
+     */
+    protected static $final = true;
+
+    /**
+     * @Flow\Inject
+     * @var NodeAccessorManager
+     */
+    protected $nodeAccessorManager;
+
+    /**
+     * @Flow\Inject
+     * @var NodeTypeConstraintFactory
+     */
+    protected $nodeTypeConstraintFactory;
+
+    /**
+     * {@inheritdoc}
+     *
+     * We can only handle ContentRepository Nodes.
+     *
+     * @param mixed $context
+     * @return boolean
+     */
+    public function canEvaluate($context)
+    {
+        return (isset($context[0]) && ($context[0] instanceof NodeInterface));
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param FlowQuery $flowQuery the FlowQuery object
+     * @param array $arguments the arguments for this operation
+     * @return void
+     */
+    public function evaluate(FlowQuery $flowQuery, array $arguments)
+    {
+        /** @var NodeInterface $contextNode */
+        $contextNode = $flowQuery->getContext()[0];
+        $nodeAccessor = $this->nodeAccessorManager->accessorFor(
+            $contextNode->getContentStreamIdentifier(),
+            $contextNode->getDimensionSpacePoint(),
+            $contextNode->getVisibilityConstraints()
+        );
+        $nodes = $nodeAccessor->findDescendants(
+            [$contextNode],
+            $this->nodeTypeConstraintFactory->parseFilterString($arguments[1] ?? ''),
+            SearchTerm::fulltext($arguments[0] ?? '')
+        );
+        $flowQuery->setContext($nodes);
+    }
+}

--- a/Neos.EventSourcedNeosAdjustments/Classes/Ui/Fusion/Helper/NodeInfoHelper.php
+++ b/Neos.EventSourcedNeosAdjustments/Classes/Ui/Fusion/Helper/NodeInfoHelper.php
@@ -26,7 +26,6 @@ use Neos\EventSourcedNeosAdjustments\Ui\Service\Mapping\NodePropertyConverterSer
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Mvc\Controller\ControllerContext;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
-use Neos\Neos\Domain\Service\ContentContext;
 use Neos\Neos\TypeConverter\EntityToIdentityConverter;
 use Neos\Neos\Ui\Domain\Service\UserLocaleService;
 use Neos\Neos\Ui\Service\NodePolicyService;
@@ -307,7 +306,7 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
             $nodeAccessor = $this->nodeAccessorManager->accessorFor($node->getContentStreamIdentifier(), $node->getDimensionSpacePoint(), VisibilityConstraints::withoutRestrictions());
 
             $nodePath = $nodeAccessor->findNodePath($node);
-            if (array_key_exists($nodePath, $renderedNodes)) {
+            if (array_key_exists($nodePath->jsonSerialize(), $renderedNodes)) {
                 $renderedNodes[(string)$nodePath]['matched'] = true;
             } elseif ($renderedNode = $this->renderNodeWithMinimalPropertiesAndChildrenInformation($node, $controllerContext, $baseNodeTypeOverride)) {
                 $renderedNode['matched'] = true;
@@ -316,21 +315,14 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
                 continue;
             }
 
-            /* @var $contentContext ContentContext */
-            $contentContext = $node->getContext();
-            // TODO: $node->getContext() not supported anymore
-            $siteNodePath = $contentContext->getCurrentSiteNode()->getPath();
             $parentNode = $nodeAccessor->findParentNode($node);
             if ($parentNode === null) {
                 // There are a multitude of reasons why a node might not have a parent and we should ignore these gracefully.
                 continue;
             }
 
-            // we additionally need to check that our parent nodes are underneath the site node; otherwise it might happen that
-            // we try to send the "/sites" node to the UI (which we cannot do, because this does not have an URL)
             $parentNodePath = $nodeAccessor->findNodePath($parentNode);
-            $parentNodeIsUnderneathSiteNode = (strpos((string)$parentNodePath, $siteNodePath) === 0);
-            while ($parentNode->getNodeType()->isOfType($baseNodeTypeOverride) && $parentNodeIsUnderneathSiteNode) {
+            while ($parentNode->getNodeType()->isOfType($baseNodeTypeOverride)) {
                 if (array_key_exists((string)$parentNodePath, $renderedNodes)) {
                     $renderedNodes[(string)$parentNodePath]['intermediate'] = true;
                 } else {
@@ -340,7 +332,7 @@ class NodeInfoHelper implements ProtectedContextAwareInterface
                         $renderedNodes[(string)$parentNodePath] = $renderedParentNode;
                     }
                 }
-                $parentNode = $parentNode->getParent();
+                $parentNode = $nodeAccessor->findParentNode($parentNode);
                 if ($parentNode === null) {
                     // There are a multitude of reasons why a node might not have a parent and we should ignore these gracefully.
                     break;


### PR DESCRIPTION
Re-implements the `\Neos\Neos\Ui\FlowQueryOperations\SearchOperation`
of the `neos/neos-ui` package using the Content Graph fulltext search.

This will be required in order to make the backend search functionality
work.

Related: #204